### PR TITLE
fix: support errors containing simple strings

### DIFF
--- a/tools/log-viewer/scripts.js
+++ b/tools/log-viewer/scripts.js
@@ -269,7 +269,13 @@ class RewrittenData {
 
   errors(value) {
     if (!value || value.length === 0) return '-';
-    const errs = value.map((err) => `${err.message} (${err.target})`);
+    const errs = value.map((err) => {
+      const { message, target } = err;
+      if (message) {
+        return `${message} (${target})`;
+      }
+      return err;
+    });
     return errs.join(', <br />');
   }
 


### PR DESCRIPTION
Fix #42 

Test URLs:
- Before: https://main--helix-tools-website--adobe.hlx.live/
- After: https://support-error-strings--helix-tools-website--adobe.hlx.live/

You need to look at a site that has purge errors, e.g. https://main--aemms--adobe.hlx.page/ , filter by `live` and open up the `Details` pane.