### PR TITLE
feat: org/site project entry

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -547,6 +547,32 @@ select[readonly]:focus {
   outline: 0;
 }
 
+.form-field.config-field {
+  display: grid;
+}
+
+@media (width >= 600px) {
+  .form-field.config-field {
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-l);
+  }
+
+  .form-field.config-field .form-field {
+    margin-top: 0;
+  }
+
+  .form-field.config-field .site-field {
+    position: relative;
+  }
+
+  .form-field.config-field .site-field::before {
+    content: '/';
+    position: absolute;
+    left: calc((var(--spacing-l) + 0.5ch) / -2);
+    bottom: calc(var(--border-m) + 0.4em);
+  }
+}
+
 .form-field.file-field {
   position: relative;
   min-height: 320px;

--- a/tools/log-viewer/index.html
+++ b/tools/log-viewer/index.html
@@ -27,13 +27,18 @@
     <div>
       <form id="timeframe-form">
 
-        <div class="form-field url-field">
-          <label for="site-url">Site URL</label>
-          <input name="site-url" id="site-url" type="url" required />
-          <div class="field-help-text">
-            <p>hlx/aem page & live URLs supported.</p>
+        <section class="form-field config-field">
+          <div class="form-field org-field">
+            <label for="org">Organization</label>
+            <input name="org" id="org" list="org-list" required />
+            <datalist id="org-list"></datalist>
           </div>
-        </div>
+          <div class="form-field site-field">
+            <label for="site">Site</label>
+            <input name="site" id="site" list="site-list" disabled required />
+            <datalist id="site-list"></datalist>
+          </div>
+        </section>
 
         <section class="form-field timeframe-wrapper">
           <!-- <button type="button" class="button">

--- a/tools/log-viewer/scripts.js
+++ b/tools/log-viewer/scripts.js
@@ -461,51 +461,6 @@ function displayLogs(logs, live, preview) {
   updateTableDisplay(logs.length ? 'results' : 'no-results', TABLE);
 }
 
-function toggleCustomTimeframe(enabled) {
-  const picker = document.getElementById('timeframe');
-  const datetime = picker.parentElement.querySelector('.datetime-wrapper');
-  picker.dataset.custom = enabled;
-  datetime.hidden = !enabled;
-  [...datetime.children].forEach((child) => {
-    child.setAttribute('aria-hidden', !enabled);
-  });
-}
-
-function updateTimeframe(value) {
-  const now = new Date();
-  const from = document.getElementById('date-from');
-  const to = document.getElementById('date-to');
-  [from, to].forEach((field) => {
-    field.readOnly = true;
-  });
-  to.value = toDateTimeLocal(now);
-  toggleCustomTimeframe(value === 'custom');
-  if (value.includes(':')) {
-    const [days, hours, mins] = value.split(':').map((v) => parseInt(v, 10));
-    const date = calculatePastDate(days, hours, mins);
-    from.value = toDateTimeLocal(date);
-  } else if (value === 'today') {
-    const midnight = now;
-    midnight.setHours(0, 0, 0, 0);
-    from.value = toDateTimeLocal(midnight);
-  } else if (value === 'custom') {
-    [from, to].forEach((field) => {
-      field.removeAttribute('readonly');
-    });
-  }
-}
-
-function keepToFromCurrent(doc) {
-  const to = doc.getElementById('date-to');
-  to.setAttribute('max', toDateTimeLocal(new Date()));
-  const timeframe = doc.getElementById('timeframe');
-  if (timeframe.value !== 'Custom') {
-    const options = [...timeframe.parentElement.querySelectorAll('ul > li')];
-    const { value } = options.find((o) => o.textContent === timeframe.value).dataset;
-    updateTimeframe(value);
-  }
-}
-
 /**
  * Constructs query params based on the provided timeframe.
  * @param {string} timeframe - Timeframe for logs.
@@ -882,17 +837,23 @@ function registerListeners() {
 
 registerListeners();
 
-function initDateTo(doc) {
-  const to = doc.getElementById('date-to');
-  to.value = toDateTimeLocal(new Date());
-
+/**
+ * Initializes the max date value for date input fields and updates it every minute.
+ * @param {HTMLInputElement} from - "from" date input element.
+ * @param {HTMLInputElement} to - "to" date input element.
+ */
+function initDateMax(from, to) {
+  [from, to].forEach((d) => {
+    d.max = toDateTimeLocal(new Date());
+  });
   setInterval(() => {
-    keepToFromCurrent(doc);
-  }, 60 * 100);
+    [from, to].forEach((d) => {
+      d.max = toDateTimeLocal(new Date());
+    });
+  }, 60 * 1000);
 }
 
-initDateTo(document);
-updateTimeframe('1:00:00');
+initDateMax(FROM, TO);
 
 /**
  * Populates fields with values from URL query params.

--- a/tools/log-viewer/scripts.js
+++ b/tools/log-viewer/scripts.js
@@ -189,7 +189,7 @@ function selectTimeframe(timeframe) {
   const custom = timeframe === 'Custom';
   // select picker option
   PICKER_OPTIONS.forEach((option) => {
-    option.setAttribute('aria-selected', option.dataset.value === timeframe.toLowerCase());
+    option.setAttribute('aria-selected', option.dataset.value === timeframe.toLowerCase() || option.textContent.toLowerCase() === timeframe.toLowerCase());
   });
   PICKER.dataset.custom = custom;
   PICKER.value = timeframe;
@@ -241,7 +241,7 @@ function updateTableError(status, preview, site) {
 
 function clearTable(table) {
   table.innerHTML = '';
-  updateTableDisplay('no-results', table.closest('table'));
+  updateTableDisplay('no-results', TABLE);
 }
 
 class RewrittenData {
@@ -412,7 +412,7 @@ class RewrittenData {
   }
 }
 
-function buildLog(data, host) {
+function buildLog(data, live, preview) {
   const row = document.createElement('tr');
   const cols = [
     'timestamp',
@@ -433,7 +433,7 @@ function buildLog(data, host) {
     'status',
     'duration',
   ];
-  const formattedData = new RewrittenData(data, host);
+  const formattedData = new RewrittenData(data, live, preview);
   formattedData.rewrite(cols);
 
   cols.forEach((col) => {

--- a/tools/log-viewer/scripts.js
+++ b/tools/log-viewer/scripts.js
@@ -810,22 +810,23 @@ function registerListeners() {
   RESULTS.addEventListener('click', async (e) => {
     const { target } = e;
     if (target.dataset.url) {
+      showLoadingButton(target);
       try {
-        showLoadingButton(target);
         const url = new URL(target.dataset.url);
         const { createModal } = await import('../../blocks/modal/modal.js');
         const res = await fetch(url);
         const json = await res.json();
         const modal = document.createElement('div');
-        modal.innerHTML = `<pre>${JSON.stringify(json, null, 2)}
-          </pre>`;
+        modal.innerHTML = `<pre><code class="language-js">${JSON.stringify(json, null, 2)}
+          </code></pre>`;
         const { showModal } = await createModal(modal.childNodes);
-        resetLoadingButton(target);
+        highlight(document.querySelector('.modal'));
         showModal();
       } catch (error) {
         // eslint-disable-next-line no-console
         console.log('Could not create modal:', error);
       }
+      resetLoadingButton(target);
     }
   });
 


### PR DESCRIPTION
replace `#site-url` field with more dynamic org/site combo field. org and site will autofill and offer autocomplete options based on previous tool usage (eventual plan to roll out across tools/labs for shared functionality). 

order of operations for autofill:
1. org/site will be populated by **url params**
2. if no url params, org/site will be populated by **localStorage**
3. if no localStorage, org will be populated by **sidekick**

on successful form submission, the current org/site config will be added the url params (for easy sharing) and localStorage. after first successful use, org/site should always auto-populate for continued ease of use in the future.

additionally, live and preview links are collected from an admin status call (hlx sites still use hlx, aem sites will use aem).

Test URLs:
- Before: https://tools.aem.live/tools/log-viewer/index.html?org=adobe&site=helix-tools-website
- After: https://org-site--helix-tools-website--adobe.aem.live/tools/log-viewer/index.html?org=adobe&site=helix-tools-website
