### PR TITLE
give the right status code error when /status fails

### DIFF
--- a/tools/log-viewer/scripts.js
+++ b/tools/log-viewer/scripts.js
@@ -595,7 +595,7 @@ async function fetchLogs(org, site, timeframe) {
  */
 async function fetchHosts(org, site) {
   try {
-    const url = `https://admin.hlx.page/status/${org}/${site}/main`;
+    const url = `https://admin.hlx.page/status/${org}/${site}/main/`;
     const res = await fetch(url);
     if (!res.ok) throw res;
     const json = await res.json();
@@ -604,6 +604,7 @@ async function fetchHosts(org, site) {
       preview: new URL(json.preview.url).host,
     };
   } catch (error) {
+    updateTableError(error.status, `main--${site}--${org}.hlx.page`, `${org}/${site}`);
     return {
       live: null,
       preview: null,
@@ -695,8 +696,6 @@ function registerListeners() {
         } else {
           updateTableError(error.status, preview, site);
         }
-      } else {
-        updateTableError('Project', null, `${org}/${site}`);
       }
     }
 


### PR DESCRIPTION
defaulted the error message on fail of /status to login to .hlx.page for now until there is a better way to do this

Fix #53 

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/log-viewer/index.html?org=adobe&site=helix-tools-website&date-from=2024-11-17T21%3A16&date-to=2024-11-19T21%3A16 
- After: https://log-viewer-error-handling--helix-tools-website--adobe.aem.live/tools/log-viewer/index.html?org=adobe&site=helix-tools-website&date-from=2024-11-17T21%3A16&date-to=2024-11-19T21%3A16 