### PR TITLE
fix: add editUrlLabel & editUrlPattern to sidekick config schema

### DIFF
--- a/sidekick/config.schema.json
+++ b/sidekick/config.schema.json
@@ -211,7 +211,7 @@
     },
     "editUrlPattern": {
       "type": "string",
-      "description": "The URL pattern for the custom editing environment."
+      "description": "The URL pattern for the custom editing environment. Supports placeholders like {{contentSourceUrl}} or {{pathname}}."
     }
    },
    "additionalProperties": false

--- a/sidekick/config.schema.json
+++ b/sidekick/config.schema.json
@@ -204,6 +204,14 @@
     "specialViews": {
       "type": "array",
       "items": { "$ref": "#/$defs/specialView" }
+    },
+    "editUrlLabel": {
+      "type": "string",
+      "description": "The label of the custom editing environment."
+    },
+    "editUrlPattern": {
+      "type": "string",
+      "description": "The URL pattern for the custom editing environment."
     }
    },
    "additionalProperties": false


### PR DESCRIPTION
Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/
- After: https://sidekick-schema-edit--helix-tools-website--adobe.aem.live/
