### PR TITLE
fix: 401 leads to undefined site link

### DIFF
--- a/tools/log-viewer/scripts.js
+++ b/tools/log-viewer/scripts.js
@@ -604,7 +604,7 @@ async function fetchHosts(org, site) {
       preview: new URL(json.preview.url).host,
     };
   } catch (error) {
-    return { error };
+    return { error, preview: `main--${site}--${org}.aem.page` };
   }
 }
 


### PR DESCRIPTION
When not logged in, the link to the site is `https://undefined` due to https://github.com/adobe/helix-tools-website/blob/main/tools/log-viewer/scripts.js#L273

adding estimated preview url to the error return to fix.

Test URLs:
- Before: https://main--helix-tools-website--adobe.hlx.live/tools/log-viewer/index.html
- After: https://undefined-login--helix-tools-website--adobe.hlx.live/tools/log-viewer/index.html
