### PR TITLE
fix:saving index configuration 

### DIFF
--- a/tools/index-admin/index-admin.js
+++ b/tools/index-admin/index-admin.js
@@ -367,7 +367,7 @@ function populateIndexes(indexes) {
             reindexBtn.disabled = false;
             detailsUrl = null;
           }
-        }, 1000);
+        }, 10000);
 
         reindexBtn.textContent = 'Reindexing... 0/0';
       } else {

--- a/tools/page-status/orphaned-pages-popover.js
+++ b/tools/page-status/orphaned-pages-popover.js
@@ -157,7 +157,7 @@ function pollJob(detailsURL) {
         });
       });
     }
-  }, 1000);
+  }, 10000);
 }
 
 async function init() {

--- a/tools/page-status/scripts.js
+++ b/tools/page-status/scripts.js
@@ -500,10 +500,10 @@ async function fetchJobUrl(org, site, path) {
 /**
  * Polls job URL then fetches additional details and returns job resources.
  * @param {string} url - Job URL.
- * @param {number} [retry=2000] - Delay (in ms) between polling attempts.
+ * @param {number} [retry=10000] - Delay (in ms) between polling attempts.
  * @returns {Promise<Object[]>} Array of resources.
  */
-async function runJob(url, retry = 2000) {
+async function runJob(url, retry = 10000) {
   try {
     const jobRes = await fetch(url, { mode: 'cors' });
     if (!jobRes.ok) throw jobRes;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/index-admin/index.html
- After: https://index-admin-on-save--helix-tools-website--adobe.aem.live/tools/index-admin/index.html

Changes 
- Making YAML library available when saving the query.yaml for the first time as it was undefined 
- Adding indexing job monitoring and showing that on the Reindex button as well as in console block