### PR TITLE
feat: adding download option to log viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ MIGRATION_PLAN.md
 !AGENTS.md
 
 .playwright-mcp/
+.claude/settings.local.json

--- a/tools/log-viewer/index.html
+++ b/tools/log-viewer/index.html
@@ -92,6 +92,7 @@
         <p class="button-wrapper">
           <button type="submit" class="button">Submit</button>
           <button type="reset" id="site-reset" class="button outline">Reset</button>
+          <button type="button" class="button disabled" id="download-csv">Download CSV</button>
         </p>
       </form>
     </div>

--- a/tools/log-viewer/styles.css
+++ b/tools/log-viewer/styles.css
@@ -336,3 +336,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Download button disabled state */
+a.disabled,
+button.disabled {
+  pointer-events: none;
+  border-color: var(--gray-100);
+  background-color: var(--color-background);
+  color: var(--gray-400);
+}


### PR DESCRIPTION
Adding a download button for users to download the logs for a certain time span to then use in Excel or more powerful tools. Requested by CME Group.

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/log-viewer/index.html
- After: https://log-viewer-export-csv--helix-tools-website--adobe.aem.live/tools/log-viewer/index.html
