### PR TITLE
feat: link to create content

### DIFF
--- a/widgets/bot-info/bot-info.html
+++ b/widgets/bot-info/bot-info.html
@@ -20,12 +20,13 @@
 
 
     <h2>What's next:</h2>
+    
+    <h3>Create your content:</h3>
+    <span class="bot-info-content-source">https://da.live/start?org=aemtutorial&site=mysite</span>
+
     <h3>Check your site:</h3>
     <p>Preview: <a target="_blank" class="bot-info-preview" href="https://main--mysite--aemtutorial.aem.page/">https://main--mysite--aemtutorial.aem.page/</a></p>
     <p>Live: <a target="_blank" class="bot-info-live" href="https://main--mysite--aemtutorial.aem.live/">https://main--mysite--aemtutorial.aem.live/</a></p>
-
-    <h3>Edit your content:</h3>
-    <span class="bot-info-content-source">https://da.live/#/aemtutorial/mysite</span>
 
     <h3>Add users:</h3>
     <p>Use the admin tool: <a target="_blank" class="bot-info-user-admin" href="https://labs.aem.live/tools/user-admin/index.html">https://labs.aem.live/tools/user-admin/index.html</a></p>

--- a/widgets/bot-info/bot-info.js
+++ b/widgets/bot-info/bot-info.js
@@ -6,11 +6,6 @@ export default function decorate(widget) {
     const org = toClassName(params.get('org'));
     const site = toClassName(params.get('site'));
     const user = params.get('user');
-    const url = params.get('url');
-
-    // set content source link
-    const contentSource = document.querySelector('.bot-info-content-source');
-    const authorUrl = new URL(url.replace('https://content.da.live', 'https://da.live#'));
 
     if (!user) {
       const userElement = document.querySelector('.bot-info-user');
@@ -23,37 +18,36 @@ export default function decorate(widget) {
       adminNoteNoUser.removeAttribute('aria-hidden');
     }
 
-    if (authorUrl.protocol === 'https:') {
-      const editUrl = authorUrl.toString();
+    const contentSource = document.querySelector('.bot-info-content-source');
+    const editUrl = `https://da.live/start?org=${org}&site=${site}`;
 
-      const editLink = document.createElement('a');
-      editLink.target = '_blank';
-      editLink.href = editUrl;
-      editLink.textContent = editUrl;
-      contentSource.textContent = '';
-      contentSource.appendChild(editLink);
+    const editLink = document.createElement('a');
+    editLink.target = '_blank';
+    editLink.href = editUrl;
+    editLink.textContent = editUrl;
+    contentSource.textContent = '';
+    contentSource.appendChild(editLink);
 
-      const orgElement = document.querySelector('.bot-info-org');
-      orgElement.textContent = org;
+    const orgElement = document.querySelector('.bot-info-org');
+    orgElement.textContent = org;
 
-      const userElement = document.querySelector('.bot-info-user');
-      userElement.textContent = user;
+    const userElement = document.querySelector('.bot-info-user');
+    userElement.textContent = user;
 
-      const siteElement = document.querySelector('.bot-info-site');
-      siteElement.textContent = site;
+    const siteElement = document.querySelector('.bot-info-site');
+    siteElement.textContent = site;
 
-      const previewLink = document.querySelector('.bot-info-preview');
-      previewLink.href = `https://main--${site}--${org}.aem.page/`;
-      previewLink.textContent = `https://main--${site}--${org}.aem.page/`;
+    const previewLink = document.querySelector('.bot-info-preview');
+    previewLink.href = `https://main--${site}--${org}.aem.page/`;
+    previewLink.textContent = `https://main--${site}--${org}.aem.page/`;
 
-      const liveLink = document.querySelector('.bot-info-live');
-      liveLink.href = `https://main--${site}--${org}.aem.live/`;
-      liveLink.textContent = `https://main--${site}--${org}.aem.live/`;
+    const liveLink = document.querySelector('.bot-info-live');
+    liveLink.href = `https://main--${site}--${org}.aem.live/`;
+    liveLink.textContent = `https://main--${site}--${org}.aem.live/`;
 
-      widget.querySelectorAll('.bot-info-user-admin').forEach((link) => {
-        link.href = `https://labs.aem.live/tools/user-admin/index.html?org=${org}&site=${site}`;
-      });
-    }
+    widget.querySelectorAll('.bot-info-user-admin').forEach((link) => {
+      link.href = `https://labs.aem.live/tools/user-admin/index.html?org=${org}&site=${site}`;
+    });
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);


### PR DESCRIPTION
In DA, "anonymous" is not allowed to create content anymore, i.e. default content cannot be created on behalf of the user creating the project. Instead of referencing the direct access to the content, we need to guide users to da.live/start where they can then create their content.

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/bot/setup?user=&site=helix-test-v1&url=https%3A%2F%2Fcontent.da.live%2Fkptdobe%2Fhelix-test-v1%2F&site=daauth&url=https%3A%2F%2Fcontent.da.live%2Fkptdobe%2Fdaauth%2F&org=kptdobe

- After: https://create-content--helix-tools-website--adobe.aem.live/bot/setup?user=&site=helix-test-v1&url=https%3A%2F%2Fcontent.da.live%2Fkptdobe%2Fhelix-test-v1%2F&site=daauth&url=https%3A%2F%2Fcontent.da.live%2Fkptdobe%2Fdaauth%2F&org=kptdobe
