### PR TITLE
feat(error-analyzer): add path prefix filter

### DIFF
--- a/tools/error-analyzer/error-analyzer.css
+++ b/tools/error-analyzer/error-analyzer.css
@@ -172,83 +172,6 @@
       }
     }
 
-  .filter-indicator {
-    background-color: var(--blue-200);
-    border: var(--border-s) solid var(--blue-500);
-    border-radius: var(--rounding-m);
-    padding: var(--spacing-s);
-    margin: 0 var(--spacing-s) var(--spacing-m);
-    display: none;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--spacing-m);
-    font-size: var(--body-size-s);
-
-    &.active {
-      display: flex;
-    }
-
-    .filter-content {
-      display: flex;
-      flex-direction: column;
-      gap: var(--spacing-xs);
-      flex: 1;
-
-      @media (width >= 900px) {
-        flex-direction: row;
-        gap: var(--spacing-m);
-      }
-    }
-
-    .filter-item {
-      display: flex;
-      align-items: center;
-      gap: var(--spacing-xs);
-      flex-wrap: wrap;
-
-      strong {
-        color: var(--gray-900);
-        white-space: nowrap;
-      }
-
-      a {
-        color: var(--blue-1000);
-        text-decoration: underline;
-        word-break: break-all;
-        
-        &:hover {
-          text-decoration: none;
-        }
-      }
-    }
-
-    .filter-text {
-      font-family: var(--code-font-family);
-      font-size: var(--body-size-s);
-      background-color: var(--layer-depth);
-      padding: var(--spacing-xs) var(--spacing-s);
-      border-radius: var(--rounding-s);
-      color: var(--blue-1000);
-      word-break: break-all;
-      font-weight: var(--weight-bold);
-    }
-
-    .clear-filter {
-      background-color: var(--blue-900);
-      color: white;
-      border: none;
-      border-radius: var(--rounding-s);
-      padding: var(--spacing-xs) var(--spacing-s);
-      cursor: pointer;
-      font-size: var(--body-size-s);
-      white-space: nowrap;
-
-      &:hover {
-        background-color: var(--blue-800);
-      }
-    }
-  }
-
   .errors-header {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
@@ -287,71 +210,106 @@
         gap: var(--spacing-s);
       }
 
-      .path-filter-wrapper {
-        position: relative;
+      .filter-panel-trigger {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        border: var(--border-s) solid var(--gray-300);
+        border-radius: var(--rounding-m);
+        background-color: var(--color-background);
+        cursor: pointer;
+        transition: all 0.15s ease;
 
-        .path-filter-trigger {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          width: 28px;
-          height: 28px;
-          padding: 0;
-          border: var(--border-s) solid var(--gray-300);
-          border-radius: var(--rounding-m);
-          background-color: var(--color-background);
-          cursor: pointer;
-          transition: all 0.15s ease;
+        .icon {
+          width: 14px;
+          height: 14px;
+        }
+
+        &:hover {
+          background-color: var(--gray-200);
+          border-color: var(--gray-400);
+        }
+
+        &.has-filters {
+          background-color: var(--blue-900);
+          border-color: var(--blue-900);
+          color: white;
 
           .icon {
-            width: 14px;
-            height: 14px;
+            filter: brightness(0) invert(1);
           }
 
           &:hover {
-            background-color: var(--gray-200);
-            border-color: var(--gray-400);
+            background-color: var(--blue-800);
+            border-color: var(--blue-800);
           }
         }
+      }
+    }
 
-        .path-filter-dropdown {
-          position: absolute;
-          top: calc(100% + var(--spacing-xs));
-          right: 0;
-          z-index: 200;
-          display: none;
+    .filter-panel {
+      max-height: 0;
+      overflow: hidden;
+      background-color: var(--gray-100);
+      border-bottom: none;
+      transition: max-height 0.3s ease, padding 0.3s ease, border-bottom 0.3s ease;
+
+      &.open {
+        max-height: 400px;
+        padding: var(--spacing-m);
+        border-bottom: var(--border-s) solid var(--gray-300);
+      }
+
+      .filter-panel-content {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--spacing-m);
+
+        @media (width >= 900px) {
+          grid-template-columns: repeat(3, 1fr) auto;
+          align-items: center;
+        }
+      }
+
+      .filter-field {
+        position: relative;
+
+        label {
+          display: block;
+          font-size: var(--body-size-xs);
+          font-weight: var(--weight-medium);
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          color: var(--gray-700);
+          margin-bottom: var(--spacing-xs);
+        }
+
+        input {
+          width: 100%;
+          font-size: var(--body-size-s);
+        }
+
+        #filter-path {
+          font-family: var(--code-font-family);
+        }
+      }
+
+      .filter-actions {
+        display: flex;
+        gap: var(--spacing-s);
+        justify-content: flex-end;
+
+        @media (width >= 900px) {
           flex-direction: column;
-          gap: var(--spacing-s);
-          min-width: 280px;
-          padding: var(--spacing-m);
-          background-color: var(--color-background);
-          border: var(--border-s) solid var(--gray-300);
-          border-radius: var(--rounding-m);
-          box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+        }
 
-          &.open {
-            display: flex;
-          }
-
-          label {
-            font-size: var(--body-size-s);
-            font-weight: var(--weight-medium);
-            text-transform: none;
-            letter-spacing: normal;
-            color: var(--color-text);
-          }
-
-          input {
-            font-family: var(--code-font-family);
-            font-size: var(--body-size-s);
-            text-transform: none;
-          }
-
-          .path-filter-apply {
-            align-self: flex-end;
-            padding: var(--spacing-xs) var(--spacing-m);
-            font-size: var(--body-size-s);
-          }
+        .button {
+          padding: var(--spacing-xs) var(--spacing-m);
+          font-size: var(--body-size-s);
+          white-space: nowrap;
         }
       }
     }

--- a/tools/error-analyzer/error-analyzer.js
+++ b/tools/error-analyzer/error-analyzer.js
@@ -11,7 +11,6 @@ const state = {
   domainKey: null,
   dateRange: null,
   pathPrefixFilter: null,
-  urlFilter: null,
   sourceFilter: null,
   targetFilter: null,
   showAllErrors: false,
@@ -75,8 +74,8 @@ function updateState() {
     explorerUrl.searchParams.set('domain', state.domain);
     explorerUrl.searchParams.set('domainkey', state.domainKey);
     explorerUrl.searchParams.set('view', state.dateRange || 'month');
-    if (state.urlFilter) {
-      explorerUrl.searchParams.set('url', state.urlFilter);
+    if (state.pathPrefixFilter) {
+      explorerUrl.searchParams.set('filter', state.pathPrefixFilter);
     }
     if (state.sourceFilter) {
       explorerUrl.searchParams.set('source', state.sourceFilter);
@@ -95,56 +94,20 @@ function updateState() {
     document.getElementById('date-range').value = state.dateRange;
   }
 
-  // Sync path prefix input with state
-  const pathPrefixInput = document.getElementById('path-prefix');
-  if (pathPrefixInput && state.pathPrefixFilter !== pathPrefixInput.value) {
-    pathPrefixInput.value = state.pathPrefixFilter || '';
-  }
+  // Sync filter panel inputs if they exist
+  const filterPath = document.getElementById('filter-path');
+  const filterSource = document.getElementById('filter-source');
+  const filterTarget = document.getElementById('filter-target');
+  const filterTriggerBtn = document.querySelector('.filter-panel-trigger');
 
-  const filterIndicator = document.querySelector('.filter-indicator');
-  const hasFilters = state.pathPrefixFilter || state.urlFilter
-    || state.sourceFilter || state.targetFilter;
+  if (filterPath) filterPath.value = state.pathPrefixFilter || '';
+  if (filterSource) filterSource.value = state.sourceFilter || '';
+  if (filterTarget) filterTarget.value = state.targetFilter || '';
 
-  if (hasFilters) {
-    const filters = [];
-
-    if (state.pathPrefixFilter) {
-      filters.push(`<div class="filter-item"><strong>Path:</strong> <code class="filter-text">${state.pathPrefixFilter}</code></div>`);
-    }
-
-    if (state.urlFilter) {
-      filters.push(`<div class="filter-item"><strong>URL:</strong> <a href="${state.urlFilter}" target="_blank" rel="noopener noreferrer">${state.urlFilter}</a></div>`);
-    }
-
-    if (state.sourceFilter) {
-      filters.push(`<div class="filter-item"><strong>Source:</strong> <code class="filter-text">${state.sourceFilter}</code></div>`);
-    }
-
-    if (state.targetFilter) {
-      filters.push(`<div class="filter-item"><strong>Target:</strong> <code class="filter-text">${state.targetFilter}</code></div>`);
-    }
-
-    filterIndicator.innerHTML = `
-      <div class="filter-content">
-        ${filters.join('')}
-      </div>
-      <button class="clear-filter">Clear Filters</button>
-    `;
-
-    filterIndicator.querySelector('.clear-filter').addEventListener('click', () => {
-      state.pathPrefixFilter = null;
-      state.urlFilter = null;
-      state.sourceFilter = null;
-      state.targetFilter = null;
-      updateState();
-      // eslint-disable-next-line no-use-before-define
-      refreshResults(false);
-    });
-
-    filterIndicator.classList.add('active');
-  } else {
-    filterIndicator.innerHTML = '';
-    filterIndicator.classList.remove('active');
+  if (filterTriggerBtn) {
+    const hasActiveFilters = state.pathPrefixFilter
+      || state.sourceFilter || state.targetFilter;
+    filterTriggerBtn.classList.toggle('has-filters', hasActiveFilters);
   }
 }
 
@@ -154,15 +117,14 @@ function getStateFromURL() {
   const domain = params.get('domain');
   const dateRange = params.get('dateRange');
   const pathPrefixFilter = params.get('pathPrefixFilter');
-  const urlFilter = params.get('urlFilter');
   const sourceFilter = params.get('sourceFilter');
   const targetFilter = params.get('targetFilter');
   return {
-    domain, domainKey, dateRange, pathPrefixFilter, urlFilter, sourceFilter, targetFilter,
+    domain, domainKey, dateRange, pathPrefixFilter, sourceFilter, targetFilter,
   };
 }
 
-function formatUrls(urlsObject, activeFilter = null) {
+function formatUrls(urlsObject) {
   // Convert object to array and sort by occurrence count (descending)
   const urlEntries = Object.entries(urlsObject).sort((a, b) => b[1] - a[1]);
 
@@ -170,36 +132,16 @@ function formatUrls(urlsObject, activeFilter = null) {
     return '-';
   }
 
-  // If there's an active filter, prioritize showing that URL first
-  let displayEntries;
-  if (activeFilter && activeFilter in urlsObject) {
-    // Put filtered URL first, then others
-    const filtered = [activeFilter, urlsObject[activeFilter]];
-    const others = urlEntries.filter(([url]) => url !== activeFilter);
-    displayEntries = [filtered, ...others];
-  } else {
-    displayEntries = urlEntries;
-  }
-
   // Show up to 3 URLs
-  const urlsToShow = displayEntries.slice(0, 3);
-  const remainingCount = displayEntries.length - urlsToShow.length;
+  const urlsToShow = urlEntries.slice(0, 3);
+  const remainingCount = urlEntries.length - urlsToShow.length;
 
   let result = '<ul class="url-list">';
   urlsToShow.forEach(([url, count]) => {
-    const isUrlFiltered = activeFilter === url;
     result += `<li>
       <div class="url-row">
-        <span class="url-text" tabindex="0">${url}</span>
+        <a href="${url}" class="url-text" target="_blank" rel="noopener noreferrer">${url}</a>
         <span class="url-count">(${formatNumber(count)})</span>
-      </div>
-      <div class="action-buttons">
-        <button class="filter-url-btn" data-url="${url.replace(/"/g, '&quot;')}" title="Filter by this URL" ${isUrlFiltered ? 'disabled' : ''}>
-          <span class="icon icon-filter"></span>
-        </button>
-        <a href="${url}" class="open-url-btn" target="_blank" rel="noopener noreferrer" title="Open in new tab">
-          <span class="icon icon-external"></span>
-        </a>
       </div>
     </li>`;
   });
@@ -271,11 +213,6 @@ function renderFilteredData() {
 
     li.setAttribute('data-severity', severity);
 
-    const isSourceFiltered = state.sourceFilter
-      && item.source.toLowerCase() === state.sourceFilter.toLowerCase();
-    const isTargetFiltered = state.targetFilter
-      && item.target.toLowerCase() === state.targetFilter.toLowerCase();
-
     // Extract URL from source if it exists
     // Handles two formats:
     // 1. @https://url:line:column
@@ -287,9 +224,6 @@ function renderFilteredData() {
       <div class="error-source">
         <code tabindex="0" data-value="${item.source.replace(/"/g, '&quot;')}">${item.source}</code>
         <div class="action-buttons">
-          <button class="filter-btn" data-value="${item.source.replace(/"/g, '&quot;')}" data-type="source" title="Filter by this source" ${isSourceFiltered ? 'disabled' : ''}>
-            <span class="icon icon-filter"></span>
-          </button>
           <button class="copy-btn" data-value="${item.source.replace(/"/g, '&quot;')}" title="Copy to clipboard">
             <span class="icon icon-copy"></span>
           </button>
@@ -301,15 +235,12 @@ function renderFilteredData() {
       <div class="error-target">
         <code tabindex="0" data-value="${item.target.replace(/"/g, '&quot;')}">${item.target}</code>
         <div class="action-buttons">
-          <button class="filter-btn" data-value="${item.target.replace(/"/g, '&quot;')}" data-type="target" title="Filter by this target" ${isTargetFiltered ? 'disabled' : ''}>
-            <span class="icon icon-filter"></span>
-          </button>
           <button class="copy-btn" data-value="${item.target.replace(/"/g, '&quot;')}" title="Copy to clipboard">
             <span class="icon icon-copy"></span>
           </button>
         </div>
       </div>
-      <div class="error-urls">${formatUrls(item.urls, state.urlFilter)}</div>
+      <div class="error-urls">${formatUrls(item.urls)}</div>
       <div class="error-last-seen">${item.timestamp ? formatRelativeDate(item.timestamp) : '-'}</div>
       <div class="error-count">
         <div class="count-bar">
@@ -368,23 +299,6 @@ function renderFilteredData() {
 
   updateChart(data.filtered, state.dateRange);
 
-  // Handle filter URL buttons
-  errorList.querySelectorAll('.filter-url-btn').forEach((btn) => {
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const url = btn.getAttribute('data-url');
-      state.urlFilter = url;
-      updateState();
-      // eslint-disable-next-line no-use-before-define
-      refreshResults(false);
-
-      window.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      });
-    });
-  });
-
   // Handle copy buttons
   errorList.querySelectorAll('.copy-btn').forEach((btn) => {
     btn.addEventListener('click', async (e) => {
@@ -404,35 +318,11 @@ function renderFilteredData() {
       }
     });
   });
-
-  // Handle filter buttons
-  errorList.querySelectorAll('.filter-btn').forEach((btn) => {
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const value = btn.getAttribute('data-value');
-      const type = btn.getAttribute('data-type');
-
-      if (type === 'source') {
-        state.sourceFilter = value;
-      } else if (type === 'target') {
-        state.targetFilter = value;
-      }
-
-      updateState();
-      // eslint-disable-next-line no-use-before-define
-      refreshResults(false);
-
-      window.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      });
-    });
-  });
 }
 
 async function refreshResults(refreshCached = true) {
   const {
-    domain, domainKey, dateRange, pathPrefixFilter, urlFilter, sourceFilter, targetFilter,
+    domain, domainKey, dateRange, pathPrefixFilter, sourceFilter, targetFilter,
   } = state;
   if (!domain || !domainKey) {
     return;
@@ -536,15 +426,10 @@ async function refreshResults(refreshCached = true) {
         }
       }
 
-      // Check exact URL filter
-      if (urlFilter && url !== urlFilter) {
-        return false;
-      }
-
       return true;
     };
 
-    const hasUrlFilters = pathPrefixFilter || urlFilter;
+    const hasPathFilter = !!pathPrefixFilter;
 
     data.filtered = data.cached
       .map((item) => {
@@ -556,8 +441,8 @@ async function refreshResults(refreshCached = true) {
           return null;
         }
 
-        // If URL filters are active, recalculate weights based on matching URLs
-        if (hasUrlFilters) {
+        // If path filter is active, recalculate weights based on matching URLs
+        if (hasPathFilter) {
           const filteredUrls = {};
           let filteredWeight = 0;
 
@@ -620,68 +505,149 @@ async function init() {
     <div class="error-last-seen">Last Seen</div>
     <div class="error-count">
       <span>Estimated Occurrences</span>
-      <div class="path-filter-wrapper">
-        <button class="path-filter-trigger" title="Filter by path">
-          <span class="icon icon-filter"></span>
-        </button>
-        <div class="path-filter-dropdown">
-          <label for="path-prefix">Filter by Path</label>
-          <input type="text" id="path-prefix" placeholder="/blog/">
-          <button type="button" class="path-filter-apply button">Apply</button>
-        </div>
-      </div>
+      <button class="filter-panel-trigger" title="Filters" aria-expanded="false" aria-controls="filter-panel">
+        <span class="icon icon-filter"></span>
+      </button>
     </div>
   `;
   document.getElementById('error-list').before(errorsHeader);
   decorateIcons(errorsHeader);
 
-  // Path filter dropdown logic
-  const pathFilterWrapper = errorsHeader.querySelector('.path-filter-wrapper');
-  const pathFilterTrigger = errorsHeader.querySelector('.path-filter-trigger');
-  const pathFilterDropdown = errorsHeader.querySelector('.path-filter-dropdown');
-  const pathPrefixInput = errorsHeader.querySelector('#path-prefix');
-  const pathFilterApply = errorsHeader.querySelector('.path-filter-apply');
+  // Create filter panel
+  const filterPanel = document.createElement('div');
+  filterPanel.id = 'filter-panel';
+  filterPanel.classList.add('filter-panel');
+  filterPanel.innerHTML = `
+    <div class="filter-panel-content">
+      <div class="filter-field">
+        <label for="filter-path">Path Prefix</label>
+        <input type="text" id="filter-path" placeholder="/blog/" list="path-suggestions">
+        <datalist id="path-suggestions"></datalist>
+      </div>
+      <div class="filter-field">
+        <label for="filter-source">Source</label>
+        <input type="text" id="filter-source" placeholder="Error source..." list="source-suggestions">
+        <datalist id="source-suggestions"></datalist>
+      </div>
+      <div class="filter-field">
+        <label for="filter-target">Target</label>
+        <input type="text" id="filter-target" placeholder="Error message..." list="target-suggestions">
+        <datalist id="target-suggestions"></datalist>
+      </div>
+      <div class="filter-actions">
+        <button type="button" class="filter-apply button">Apply Filters</button>
+        <button type="button" class="filter-clear button outline">Clear All</button>
+      </div>
+    </div>
+  `;
+  errorsHeader.after(filterPanel);
 
-  pathFilterTrigger.addEventListener('click', (e) => {
-    e.stopPropagation();
-    pathFilterDropdown.classList.toggle('open');
-    if (pathFilterDropdown.classList.contains('open')) {
-      pathPrefixInput.focus();
-    }
-  });
+  // Filter panel logic
+  const filterTrigger = errorsHeader.querySelector('.filter-panel-trigger');
+  const filterPathInput = filterPanel.querySelector('#filter-path');
+  const filterSourceInput = filterPanel.querySelector('#filter-source');
+  const filterTargetInput = filterPanel.querySelector('#filter-target');
+  const filterApplyBtn = filterPanel.querySelector('.filter-apply');
+  const filterClearBtn = filterPanel.querySelector('.filter-clear');
 
-  function applyPathFilter() {
-    const value = pathPrefixInput.value.trim();
-    if (state.pathPrefixFilter !== (value || null)) {
-      state.pathPrefixFilter = value || null;
-      updateState();
-      refreshResults(false);
-    }
-    pathFilterDropdown.classList.remove('open');
+  // Datalist elements for autocomplete
+  const pathDatalist = filterPanel.querySelector('#path-suggestions');
+  const sourceDatalist = filterPanel.querySelector('#source-suggestions');
+  const targetDatalist = filterPanel.querySelector('#target-suggestions');
+
+  function updateDatalistOptions() {
+    const paths = new Set();
+    const sources = new Set();
+    const targets = new Set();
+
+    data.cached.forEach((item) => {
+      sources.add(item.source);
+      targets.add(item.target);
+      Object.keys(item.urls).forEach((url) => {
+        try {
+          const { pathname } = new URL(url);
+          paths.add(pathname);
+          // Also add parent paths
+          const parts = pathname.split('/').filter(Boolean);
+          let prefix = '';
+          parts.forEach((part) => {
+            prefix += `/${part}`;
+            paths.add(prefix);
+          });
+        } catch {
+          // Ignore invalid URLs
+        }
+      });
+    });
+
+    // Sort and limit suggestions
+    const sortedPaths = Array.from(paths).sort().slice(0, 100);
+    const sortedSources = Array.from(sources).slice(0, 50);
+    const sortedTargets = Array.from(targets).slice(0, 50);
+
+    pathDatalist.innerHTML = sortedPaths.map((p) => `<option value="${p}">`).join('');
+    sourceDatalist.innerHTML = sortedSources.map((s) => `<option value="${s.replace(/"/g, '&quot;')}">`).join('');
+    targetDatalist.innerHTML = sortedTargets.map((t) => `<option value="${t.replace(/"/g, '&quot;')}">`).join('');
   }
 
-  pathFilterApply.addEventListener('click', applyPathFilter);
+  function setFilterPanelOpen(isOpen) {
+    filterPanel.classList.toggle('open', isOpen);
+    filterTrigger.setAttribute('aria-expanded', isOpen);
+  }
 
-  pathPrefixInput.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      applyPathFilter();
-    }
-    if (e.key === 'Escape') {
-      pathFilterDropdown.classList.remove('open');
+  filterTrigger.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const isOpen = !filterPanel.classList.contains('open');
+    setFilterPanelOpen(isOpen);
+    if (isOpen) {
+      filterPathInput.focus();
+      updateDatalistOptions();
     }
   });
 
-  // Close dropdown when clicking outside
+  function applyFilters() {
+    state.pathPrefixFilter = filterPathInput.value.trim() || null;
+    state.sourceFilter = filterSourceInput.value.trim() || null;
+    state.targetFilter = filterTargetInput.value.trim() || null;
+    updateState();
+    refreshResults(false);
+    setFilterPanelOpen(false);
+  }
+
+  function clearFilters() {
+    filterPathInput.value = '';
+    filterSourceInput.value = '';
+    filterTargetInput.value = '';
+    state.pathPrefixFilter = null;
+    state.sourceFilter = null;
+    state.targetFilter = null;
+    updateState();
+    refreshResults(false);
+    setFilterPanelOpen(false);
+  }
+
+  filterApplyBtn.addEventListener('click', applyFilters);
+  filterClearBtn.addEventListener('click', clearFilters);
+
+  // Handle Enter key in filter inputs
+  [filterPathInput, filterSourceInput, filterTargetInput].forEach((input) => {
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        applyFilters();
+      }
+      if (e.key === 'Escape') {
+        setFilterPanelOpen(false);
+      }
+    });
+  });
+
+  // Close panel when clicking outside
   document.addEventListener('click', (e) => {
-    if (!pathFilterWrapper.contains(e.target)) {
-      pathFilterDropdown.classList.remove('open');
+    if (!filterPanel.contains(e.target) && !filterTrigger.contains(e.target)) {
+      setFilterPanelOpen(false);
     }
   });
-
-  const filterIndicator = document.createElement('div');
-  filterIndicator.classList.add('filter-indicator');
-  document.getElementById('error-list').before(filterIndicator);
 
   const modal = document.getElementById('domain-modal');
   document.getElementById('domain-trigger').addEventListener('click', () => {
@@ -707,7 +673,6 @@ async function init() {
     state.domain = domain;
     state.domainKey = domainKey;
     state.pathPrefixFilter = null;
-    state.urlFilter = null;
     state.sourceFilter = null;
     state.targetFilter = null;
     updateState();
@@ -733,14 +698,13 @@ async function init() {
   });
 
   const {
-    domain, domainKey, dateRange, pathPrefixFilter, urlFilter, sourceFilter, targetFilter,
+    domain, domainKey, dateRange, pathPrefixFilter, sourceFilter, targetFilter,
   } = getStateFromURL();
 
   state.domain = domain;
   state.domainKey = domainKey;
   state.dateRange = dateRange;
   state.pathPrefixFilter = pathPrefixFilter;
-  state.urlFilter = urlFilter;
   state.sourceFilter = sourceFilter;
   state.targetFilter = targetFilter;
   updateState();


### PR DESCRIPTION
## Summary

Add a unified filter panel to the Error Analyzer tool, allowing users to filter errors by path prefix, source, and target.

## Changes

### Filter Panel UI
- **Slide-in filter panel** that expands from a filter button in the table header
- **Three filter fields**: Path Prefix, Source, and Target
- **Native `<datalist>` autocomplete** for all fields
  - Path suggestions extracted from URLs in error data (includes parent paths)
  - Source/target suggestions from cached error data
- **Apply Filters** button commits all filter changes at once
- **Clear All** button resets filters and closes panel
- Panel closes on Escape key or clicking outside

### Filter Behavior
- **Path filter recalculates weights** - error counts reflect only matching pages
- **Source/target filters** filter entire error groups
- Filters persist in URL for sharing/bookmarking
- Path filter passed to Explorer URL via `filter` param

### UI/UX Improvements
- Removed inline filter buttons from each row (cleaner table)
- Removed separate filter indicator bar (panel is sufficient)
- Filter button shows **prominent active state** (solid blue) when filters applied
- Inputs center-aligned on desktop

### Accessibility
- ARIA attributes: `aria-expanded`, `aria-controls` on trigger button
- Panel has `id` for ARIA reference

### Bug Fixes
- Fixed stack overflow with large timeSlots arrays (replaced `Math.max(...array)` with `reduce()`)

## Test URLs
- **Before**: https://main--helix-tools-website--adobe.aem.live/tools/error-analyzer/index.html
- **After**: https://error-paths--helix-tools-website--adobe.aem.live/tools/error-analyzer/index.html
