### PR TITLE
fix(bulk): add dark mode support

### DIFF
--- a/tools/bulk/styles.css
+++ b/tools/bulk/styles.css
@@ -26,30 +26,16 @@
   gap: var(--spacing-s);
 }
 
-.bulk-ops .status-light::before {
-  color: var(--red-900);
-}
-
-.bulk-ops .status-light.http1::before {
-  color: var(--blue-900);
-}
-
-.bulk-ops .status-light.http2::before {
-  color: var(--green-900);
-}
-
-.bulk-ops .status-light.http3::before {
-  color: var(--yellow-900);
-}
-
 /* Sanitization Warning Dialog */
 .bulk-ops dialog.sanitization-warning {
   max-width: 800px;
   max-height: 80vh;
   padding: var(--spacing-l);
-  border: 1px solid var(--gray-300);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
-  box-shadow: 0 4px 20px rgb(0 0 0 / 15%);
+  box-shadow: var(--shadow-default);
+  background-color: var(--color-background);
+  color: var(--color-text);
 }
 
 .bulk-ops dialog.sanitization-warning::backdrop {
@@ -81,7 +67,7 @@
 }
 
 .bulk-ops dialog.sanitization-warning .url-list code {
-  background: var(--gray-100);
+  background: var(--color-button-accent-bg);
   padding: 2px 6px;
   border-radius: 3px;
   font-family: var(--code-font-family);
@@ -90,25 +76,25 @@
 }
 
 .bulk-ops dialog.sanitization-warning .url-list .reason {
-  color: var(--gray-700);
+  color: var(--color-font-grey);
   font-size: var(--body-size-xs);
   font-style: italic;
 }
 
 .bulk-ops dialog.sanitization-warning .url-list.rejected li {
-  color: var(--red-800);
+  color: light-dark(var(--red-800), var(--red-500));
 }
 
 .bulk-ops dialog.sanitization-warning .url-list.modified li {
-  color: var(--yellow-900);
+  color: light-dark(var(--yellow-900), var(--yellow-500));
 }
 
 .bulk-ops dialog.sanitization-warning .url-list.deduplicated li {
-  color: var(--blue-800);
+  color: light-dark(var(--blue-800), var(--blue-500));
 }
 
 .bulk-ops dialog.sanitization-warning .url-change {
-  background: var(--gray-50);
+  background: var(--layer-elevated);
   padding: var(--spacing-xs);
   border-radius: 4px;
   margin: var(--spacing-xs) 0;
@@ -120,7 +106,7 @@
 
 .bulk-ops dialog.sanitization-warning .change-reason {
   font-size: var(--body-size-xs);
-  color: var(--gray-700);
+  color: var(--color-font-grey);
   font-style: italic;
 }
 
@@ -130,10 +116,10 @@
   justify-content: flex-end;
   margin-top: var(--spacing-l);
   padding-top: var(--spacing-m);
-  border-top: 1px solid var(--gray-200);
+  border-top: 1px solid var(--color-border);
 }
 
 .bulk-ops dialog.sanitization-warning .button.secondary {
-  background: var(--gray-200);
-  color: var(--gray-900);
+  background: var(--color-button-accent-bg);
+  color: var(--color-text);
 }


### PR DESCRIPTION
## Summary
- Remove redundant status-light overrides (now inherited from global)
- Add theme-aware styling for sanitization warning dialog (background, borders, shadows)
- Use semantic color variables for code blocks, muted text, and list items
- Use light-dark() for rejected/modified/deduplicated list colors

## Test plan
- [ ] Verify bulk tool displays correctly in dark mode
- [ ] Test sanitization warning dialog (enter invalid URLs to trigger)
- [ ] Verify status lights inherit global colors correctly

## Preview
https://dark-mode-bulk--helix-tools-website--adobe.aem.page/tools/bulk/

---
Co-authored-by: Cursor <cursor@cursor.com>

Made with [Cursor](https://cursor.com)