### PR TITLE
fix(admin-edit): add dark mode support

### DIFF
--- a/tools/admin-edit/admin-edit.css
+++ b/tools/admin-edit/admin-edit.css
@@ -58,7 +58,7 @@
   margin: 0;
   padding: 0.4em 0.85em;
   padding-bottom: calc(0.85em + (var(--body-size-s) * var(--line-height-l)));
-  border: var(--border-m) solid var(--gray-300);
+  border: var(--border-m) solid var(--color-border);
   border-radius: var(--rounding-m);
   overflow: auto;
   white-space: nowrap;
@@ -87,13 +87,13 @@
 }
 
 .admin-edit #body::-webkit-scrollbar-thumb {
-  background-color: var(--gray-500);
+  background-color: light-dark(var(--gray-500), var(--gray-400));
   border: 8px solid var(--layer-depth);
   border-radius: 12px;
 }
 
 .admin-edit #body::-webkit-scrollbar-thumb:hover {
-  background-color: var(--gray-600);
+  background-color: light-dark(var(--gray-600), var(--gray-300));
   cursor: move;
 }
 
@@ -116,22 +116,6 @@
 
 .admin-edit .status-light {
   white-space: nowrap;
-}
-
-.admin-edit .status-light::before {
-  color: var(--red-900);
-}
-
-.admin-edit .status-light.http1::before {
-  color: var(--blue-900);
-}
-
-.admin-edit .status-light.http2::before {
-  color: var(--green-900);
-}
-
-.admin-edit .status-light.http3::before {
-  color: var(--yellow-900);
 }
 
 /* PrismJS 1.29.0 (Default), slightly altered
@@ -157,11 +141,11 @@ pre[class*='language-'] {
 .token.comment,
 .token.doctype,
 .token.prolog {
-  color: #708090;
+  color: light-dark(#708090, #8b949e);
 }
 
 .token.punctuation {
-  color: #999;
+  color: light-dark(#999, #8b949e);
 }
 
 .token.namespace {
@@ -169,7 +153,7 @@ pre[class*='language-'] {
 }
 
 .token.property {
-  color: #4b0082;
+  color: light-dark(#4b0082, #d2a8ff);
 }
 
 .token.boolean,
@@ -178,7 +162,7 @@ pre[class*='language-'] {
 .token.number,
 .token.symbol,
 .token.tag {
-  color: #905;
+  color: light-dark(#905, #ff7b72);
 }
 
 .token.attr-name,
@@ -187,7 +171,7 @@ pre[class*='language-'] {
 .token.inserted,
 .token.selector,
 .token.string {
-  color: #690;
+  color: light-dark(#690, #a5d6ff);
 }
 
 .language-css .token.string,
@@ -195,24 +179,24 @@ pre[class*='language-'] {
 .token.entity,
 .token.operator,
 .token.url {
-  color: #9a6e3a;
+  color: light-dark(#9a6e3a, #ffa657);
 }
 
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #07a;
+  color: light-dark(#07a, #ff7b72);
 }
 
 .token.class-name,
 .token.function {
-  color: #dd4a68;
+  color: light-dark(#dd4a68, #d2a8ff);
 }
 
 .token.important,
 .token.regex,
 .token.variable {
-  color: #e90;
+  color: light-dark(#e90, #ffa657);
 }
 
 .token.bold,
@@ -237,7 +221,7 @@ https://prismjs.com/plugins/line-highlight/ */
   right: 0;
   margin-top: calc(var(--body-size-s) / 2.5);
   border-bottom: var(--border-m) dotted var(--red-900);
-  background-color: #d7322026;
+  background-color: light-dark(#d7322026, #f8514926);
   line-height: var(--line-height-l);
   pointer-events: none;
   white-space: pre;
@@ -276,7 +260,7 @@ https://prismjs.com/plugins/line-highlight/ */
 }
 
 .line-highlight.error-hover {
-  background-color: #d7322038;
+  background-color: light-dark(#d7322038, #f8514938);
 }
 
 .line-highlight.error-hover::before,

--- a/utils/prism/prism.css
+++ b/utils/prism/prism.css
@@ -26,11 +26,11 @@ pre[class*='language-'] {
 .token.comment,
 .token.doctype,
 .token.prolog {
-  color: #708090;
+  color: light-dark(#708090, #8b949e);
 }
 
 .token.punctuation {
-  color: #999;
+  color: light-dark(#999, #8b949e);
 }
 
 .token.namespace {
@@ -38,7 +38,7 @@ pre[class*='language-'] {
 }
 
 .token.property {
-  color: #4b0082;
+  color: light-dark(#4b0082, #d2a8ff);
 }
 
 .token.boolean,
@@ -47,7 +47,7 @@ pre[class*='language-'] {
 .token.number,
 .token.symbol,
 .token.tag {
-  color: #905;
+  color: light-dark(#905, #ff7b72);
 }
 
 .token.attr-name,
@@ -56,7 +56,7 @@ pre[class*='language-'] {
 .token.inserted,
 .token.selector,
 .token.string {
-  color: #690;
+  color: light-dark(#690, #a5d6ff);
 }
 
 .language-css .token.string,
@@ -64,24 +64,24 @@ pre[class*='language-'] {
 .token.entity,
 .token.operator,
 .token.url {
-  color: #9a6e3a;
+  color: light-dark(#9a6e3a, #ffa657);
 }
 
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #07a;
+  color: light-dark(#07a, #ff7b72);
 }
 
 .token.class-name,
 .token.function {
-  color: #dd4a68;
+  color: light-dark(#dd4a68, #d2a8ff);
 }
 
 .token.important,
 .token.regex,
 .token.variable {
-  color: #e90;
+  color: light-dark(#e90, #ffa657);
 }
 
 .token.bold,


### PR DESCRIPTION
## Summary
- Update border and scrollbar colors to use theme-aware variables
- Remove tool-specific status-light overrides (use global styles)
- Add dark mode colors for Prism syntax highlighting tokens
- Update line highlight error colors for both themes
- Also update global `utils/prism/prism.css` with same dark mode colors (benefits log-viewer, push-invalidation, json2html-simulator)

## Test plan
- [ ] Preview: https://dark-mode-admin-edit--helix-tools-website--adobe.aem.live/tools/admin-edit/index.html
- [ ] Verify syntax highlighting is readable in both light and dark modes
- [ ] Test error highlighting with invalid JSON


Made with [Cursor](https://cursor.com)