### PR TITLE
fix(index-admin): add dark mode support

### DIFF
--- a/tools/index-admin/index-admin.css
+++ b/tools/index-admin/index-admin.css
@@ -13,7 +13,7 @@
     width: 36px;
     height: 36px;
     border-radius: 50%;
-    border: 3px solid var(--gray-200);
+    border: 3px solid light-dark(var(--gray-200), var(--gray-700));
     border-top-color: var(--blue-700);
     border-right-color: var(--blue-500);
     animation-name: spinner-rotate;
@@ -31,8 +31,8 @@
     gap: var(--spacing-l);
 
     li {
-      background: linear-gradient(135deg, var(--gray-25) 0%, var(--gray-50) 100%);
-      border: 1px solid var(--gray-200);
+      background: linear-gradient(135deg, var(--layer-elevated) 0%, light-dark(var(--gray-50), var(--gray-800)) 100%);
+      border: 1px solid var(--color-border);
       border-radius: 12px;
       padding: var(--spacing-l);
       display: flex;
@@ -49,19 +49,19 @@
 
       &:hover {
         box-shadow: var(--shadow-hover);
-        border-color: var(--blue-300);
+        border-color: light-dark(var(--blue-300), var(--color-border));
       }
 
       .index-name {
         font-weight: 700;
         font-size: var(--heading-size-m);
         margin: 0;
-        color: var(--gray-800);
+        color: var(--color-text);
         text-align: center;
         padding: var(--spacing-s) 0;
-        background: var(--gray-25);
+        background: var(--layer-elevated);
         border-radius: 8px;
-        border: 1px solid var(--gray-100);
+        border: 1px solid light-dark(var(--gray-100), var(--gray-700));
         position: relative;
         z-index: 1;
       }
@@ -73,38 +73,37 @@
         gap: var(--spacing-m);
 
         .index-attribute {
-          background: var(--gray-25);
+          background: var(--layer-elevated);
           border-radius: 8px;
           padding: var(--spacing-s);
-          border: 1px solid var(--gray-100);
+          border: 1px solid light-dark(var(--gray-100), var(--gray-700));
           transition: all 0.2s ease-in-out;
 
           &:hover {
-            background: var(--blue-50);
-            border-color: var(--blue-200);
+            background: light-dark(var(--blue-50), var(--gray-800));
           }
 
           .index-attribute-name {
             font-weight: 600;
-            color: var(--gray-700);
+            color: var(--color-font-grey);
             font-size: 0.875rem;
             text-transform: uppercase;
             letter-spacing: 0.5px;
             margin-bottom: var(--spacing-xs);
             display: block;
           }
-  
+
           .index-attribute-value {
             margin: 0;
             font-family: var(--code-font-family);
             font-size: 0.8rem;
-            color: var(--gray-600);
+            color: var(--color-font-grey);
             line-height: 1.4;
             word-break: break-all;
-            background: var(--gray-75);
+            background: light-dark(var(--gray-75), var(--gray-800));
             padding: var(--spacing-xs);
             border-radius: 4px;
-            border: 1px solid var(--gray-200);
+            border: 1px solid var(--color-border);
           }
         }
       }
@@ -151,10 +150,10 @@
 
     .index-details-header {
       margin-bottom: var(--spacing-l);
-      
+
       h3 {
         margin: 0;
-        color: var(--gray-800);
+        color: var(--color-text);
         font-size: var(--heading-size-l);
       }
     }
@@ -174,22 +173,24 @@
 
         label {
           font-weight: 600;
-          color: var(--gray-700);
+          color: var(--color-font-grey);
           font-size: 0.875rem;
         }
 
         input, textarea, select {
           width: 100%;
           padding: var(--spacing-s);
-          border: 1px solid var(--gray-300);
+          border: 1px solid var(--color-border);
           border-radius: 6px;
           font-size: 0.875rem;
           transition: border-color 0.2s ease;
+          background-color: var(--color-background);
+          color: var(--color-text);
 
           &:focus {
             outline: none;
             border-color: var(--blue-500);
-            box-shadow: 0 0 0 3px var(--blue-100);
+            box-shadow: 0 0 0 3px light-dark(var(--blue-100), var(--blue-900));
           }
         }
 
@@ -214,10 +215,10 @@
 
     /* Index Properties Table Styling */
     .index-properties {
-      border: 1px solid var(--gray-300);
+      border: 1px solid var(--color-border);
       border-radius: 8px;
       overflow: hidden;
-      background: var(--gray-25);
+      background: var(--layer-elevated);
       max-height: 400px;
       display: flex;
       flex-direction: column;
@@ -227,13 +228,13 @@
         justify-content: space-between;
         align-items: center;
         padding: var(--spacing-s) var(--spacing-m);
-        background: var(--gray-25);
+        background: var(--layer-elevated);
         flex-shrink: 0;
-        border-bottom: 1px solid var(--gray-200);
+        border-bottom: 1px solid var(--color-border);
 
         h4 {
           font-weight: 600;
-          color: var(--gray-700);
+          color: var(--color-font-grey);
           font-size: 0.875rem;
           margin: 0;
         }
@@ -246,7 +247,7 @@
       .properties-container {
         flex: 1;
         overflow-y: auto;
-        background: white;
+        background: var(--color-background);
       }
 
       .properties-header {
@@ -254,8 +255,8 @@
         grid-template-columns: 1fr 1fr 1fr 140px 1fr 60px;
         gap: var(--spacing-s);
         padding: var(--spacing-s) var(--spacing-m);
-        background: var(--gray-100);
-        border-bottom: 2px solid var(--gray-300);
+        background: light-dark(var(--gray-100), var(--gray-800));
+        border-bottom: 2px solid var(--color-border);
         position: sticky;
         top: 0;
         z-index: 10;
@@ -263,7 +264,7 @@
 
         .header-cell {
           font-weight: 600;
-          color: var(--gray-700);
+          color: var(--color-font-grey);
           font-size: 0.75rem;
           text-transform: uppercase;
           letter-spacing: 0.5px;
@@ -280,8 +281,8 @@
         grid-template-columns: 1fr 1fr 1fr 140px 1fr 60px;
         gap: var(--spacing-s);
         padding: var(--spacing-s) var(--spacing-m);
-        border-bottom: 1px solid var(--gray-200);
-        background: white;
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-background);
         transition: background-color 0.2s ease;
         align-items: center;
         min-height: 48px;
@@ -291,7 +292,7 @@
         }
 
         &:hover {
-          background: var(--blue-25);
+          background: light-dark(var(--blue-25), var(--gray-800));
         }
 
         .form-field {
@@ -307,10 +308,11 @@
 
           input, select {
             padding: 8px 12px;
-            border: 1px solid var(--gray-300);
+            border: 1px solid var(--color-border);
             border-radius: 4px;
             font-size: 0.875rem;
-            background: white;
+            background: var(--color-background);
+            color: var(--color-text);
             transition: all 0.2s ease;
             height: 36px;
             width: 100%;
@@ -320,17 +322,17 @@
             &:focus {
               outline: none;
               border-color: var(--blue-500);
-              box-shadow: 0 0 0 2px var(--blue-100);
+              box-shadow: 0 0 0 2px light-dark(var(--blue-100), var(--blue-900));
             }
 
             &:hover {
-              border-color: var(--gray-400);
+              border-color: light-dark(var(--gray-400), var(--gray-500));
             }
           }
 
           input[readonly] {
-            background: var(--gray-50);
-            color: var(--gray-600);
+            background: light-dark(var(--gray-50), var(--gray-800));
+            color: var(--color-font-grey);
             cursor: not-allowed;
           }
 
@@ -378,7 +380,7 @@
 
               &:focus {
                 outline: none;
-                box-shadow: 0 0 0 2px var(--red-200);
+                box-shadow: 0 0 0 2px light-dark(var(--red-200), var(--red-900));
               }
             }
           }
@@ -391,10 +393,11 @@
   .reindex-status-dialog {
     max-width: 800px;
     width: 90vw;
-    border: 1px solid var(--gray-300);
+    border: 1px solid var(--color-border);
     border-radius: 12px;
     padding: 0;
     box-shadow: var(--shadow-hover);
+    background: var(--color-background);
 
     .reindex-status-content {
       display: flex;
@@ -407,13 +410,13 @@
       justify-content: space-between;
       align-items: center;
       padding: var(--spacing-l);
-      border-bottom: 1px solid var(--gray-200);
-      background: var(--gray-25);
+      border-bottom: 1px solid var(--color-border);
+      background: var(--layer-elevated);
       border-radius: 12px 12px 0 0;
 
       h3 {
         margin: 0;
-        color: var(--gray-800);
+        color: var(--color-text);
         font-size: var(--heading-size-m);
       }
 
@@ -422,7 +425,7 @@
         border: none;
         font-size: 2rem;
         line-height: 1;
-        color: var(--gray-600);
+        color: var(--color-font-grey);
         cursor: pointer;
         padding: 0;
         width: 32px;
@@ -434,8 +437,8 @@
         transition: all 0.2s ease;
 
         &:hover {
-          background: var(--gray-200);
-          color: var(--gray-800);
+          background: light-dark(var(--gray-200), var(--gray-700));
+          color: var(--color-text);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Update card backgrounds and borders for both themes
- Use theme-aware colors for form inputs and labels
- Update properties table styling for dark mode
- Update reindex status modal colors
- Subtle hover states that match light mode behavior

## Test plan
- [ ] Preview: https://dark-mode-index-admin--helix-tools-website--adobe.aem.live/tools/index-admin/index.html
- [ ] Verify index cards display correctly in both themes
- [ ] Test hover states are subtle in dark mode


Made with [Cursor](https://cursor.com)