### PR TITLE
fix(sitemap-admin): add dark mode support

### DIFF
--- a/tools/sitemap-admin/sitemap-admin.css
+++ b/tools/sitemap-admin/sitemap-admin.css
@@ -14,8 +14,8 @@
     gap: var(--spacing-l);
 
     li {
-      background: linear-gradient(135deg, var(--gray-25) 0%, var(--gray-50) 100%);
-      border: 1px solid var(--gray-200);
+      background: linear-gradient(135deg, var(--layer-elevated) 0%, light-dark(var(--gray-50), var(--gray-800)) 100%);
+      border: 1px solid var(--color-border);
       border-radius: 12px;
       padding: var(--spacing-l);
       display: flex;
@@ -30,19 +30,19 @@
 
       &:hover {
         box-shadow: var(--shadow-hover);
-        border-color: var(--blue-300);
+        border-color: light-dark(var(--blue-300), var(--color-border));
       }
 
       .sitemap-name {
         font-weight: 700;
         font-size: var(--heading-size-m);
         margin: 0;
-        color: var(--gray-800);
+        color: var(--color-text);
         text-align: center;
         padding: var(--spacing-s) 0;
-        background: var(--gray-25);
+        background: var(--layer-elevated);
         border-radius: 8px;
-        border: 1px solid var(--gray-100);
+        border: 1px solid light-dark(var(--gray-100), var(--gray-700));
         position: relative;
       }
 
@@ -72,20 +72,19 @@
         gap: var(--spacing-m);
 
         .sitemap-attribute {
-          background: var(--gray-25);
+          background: var(--layer-elevated);
           border-radius: 8px;
           padding: var(--spacing-s);
-          border: 1px solid var(--gray-100);
+          border: 1px solid light-dark(var(--gray-100), var(--gray-700));
           transition: all 0.2s ease-in-out;
 
           &:hover {
-            background: var(--blue-50);
-            border-color: var(--blue-200);
+            background: light-dark(var(--blue-50), var(--gray-800));
           }
 
           .sitemap-attribute-name {
             font-weight: 600;
-            color: var(--gray-700);
+            color: var(--color-font-grey);
             font-size: 0.875rem;
             text-transform: uppercase;
             letter-spacing: 0.5px;
@@ -97,13 +96,13 @@
             margin: 0;
             font-family: var(--code-font-family);
             font-size: 0.8rem;
-            color: var(--gray-600);
+            color: var(--color-font-grey);
             line-height: 1.4;
             word-break: break-all;
-            background: var(--gray-75);
+            background: light-dark(var(--gray-75), var(--gray-800));
             padding: var(--spacing-xs);
             border-radius: 4px;
-            border: 1px solid var(--gray-200);
+            border: 1px solid var(--color-border);
           }
         }
       }
@@ -136,13 +135,13 @@
       }
 
       &.multilang-sitemap {
-        border-color: var(--blue-300);
-        background: linear-gradient(135deg, var(--blue-25) 0%, var(--blue-50) 100%);
+        border-color: light-dark(var(--blue-300), var(--blue-800));
+        background: linear-gradient(135deg, light-dark(var(--blue-25), var(--gray-800)) 0%, light-dark(var(--blue-50), var(--gray-700)) 100%);
 
         .sitemap-name {
-          background: var(--blue-50);
-          border-color: var(--blue-200);
-          color: var(--blue-900);
+          background: light-dark(var(--blue-50), var(--gray-700));
+          border-color: light-dark(var(--blue-200), var(--blue-800));
+          color: light-dark(var(--blue-900), var(--blue-400));
         }
       }
     }
@@ -155,10 +154,10 @@
     gap: var(--spacing-xs);
 
     .language-item {
-      background: var(--gray-25);
+      background: var(--layer-elevated);
       padding: var(--spacing-s);
       border-radius: 6px;
-      border: 1px solid var(--gray-200);
+      border: 1px solid var(--color-border);
       display: flex;
       justify-content: space-between;
       align-items: center;
@@ -166,8 +165,7 @@
       transition: all 0.2s ease;
 
       &:hover {
-        border-color: var(--blue-300);
-        background: var(--blue-25);
+        background: light-dark(var(--blue-25), var(--gray-800));
       }
 
       .language-info {
@@ -177,13 +175,13 @@
         gap: var(--spacing-xs);
 
         strong {
-          color: var(--blue-700);
+          color: light-dark(var(--blue-700), var(--blue-400));
           font-family: var(--code-font-family);
           font-size: 0.875rem;
         }
 
         span {
-          color: var(--gray-600);
+          color: var(--color-font-grey);
           font-size: 0.8rem;
           font-family: var(--code-font-family);
         }
@@ -209,7 +207,7 @@
 
       h3 {
         margin: 0;
-        color: var(--gray-800);
+        color: var(--color-text);
         font-size: var(--heading-size-l);
       }
     }
@@ -229,7 +227,7 @@
 
         label {
           font-weight: 600;
-          color: var(--gray-700);
+          color: var(--color-font-grey);
           font-size: 0.875rem;
         }
 
@@ -237,15 +235,17 @@
         textarea,
         select {
           padding: var(--spacing-s);
-          border: 1px solid var(--gray-300);
+          border: 1px solid var(--color-border);
           border-radius: 6px;
           font-size: 0.875rem;
           transition: border-color 0.2s ease;
+          background-color: var(--color-background);
+          color: var(--color-text);
 
           &:focus {
             outline: none;
             border-color: var(--blue-500);
-            box-shadow: 0 0 0 3px var(--blue-100);
+            box-shadow: 0 0 0 3px light-dark(var(--blue-100), var(--blue-900));
           }
         }
 
@@ -257,8 +257,8 @@
         }
 
         input[readonly] {
-          background: var(--gray-50);
-          color: var(--gray-600);
+          background: light-dark(var(--gray-50), var(--gray-800));
+          color: var(--color-font-grey);
           cursor: not-allowed;
         }
       }
@@ -280,7 +280,7 @@
       .sitemap-details-header {
         p {
           margin: var(--spacing-s) 0 0 0;
-          color: var(--gray-600);
+          color: var(--color-font-grey);
           font-size: var(--body-size-s);
         }
       }
@@ -292,7 +292,8 @@
     border: none;
     border-radius: 12px;
     padding: 0;
-    box-shadow: 0 8px 32px rgb(0 0 0 / 15%);
+    box-shadow: var(--shadow-hover);
+    background: var(--color-background);
 
     &::backdrop {
       background: rgb(0 0 0 / 50%);
@@ -306,7 +307,7 @@
 
         h3 {
           margin: 0;
-          color: var(--gray-800);
+          color: var(--color-text);
           font-size: var(--heading-size-l);
         }
       }
@@ -326,27 +327,29 @@
 
           label {
             font-weight: 600;
-            color: var(--gray-700);
+            color: var(--color-font-grey);
             font-size: 0.875rem;
           }
 
           input {
             padding: var(--spacing-s);
-            border: 1px solid var(--gray-300);
+            border: 1px solid var(--color-border);
             border-radius: 6px;
             font-size: 0.875rem;
             transition: border-color 0.2s ease;
+            background-color: var(--color-background);
+            color: var(--color-text);
 
             &:focus {
               outline: none;
               border-color: var(--blue-500);
-              box-shadow: 0 0 0 3px var(--blue-100);
+              box-shadow: 0 0 0 3px light-dark(var(--blue-100), var(--blue-900));
             }
           }
 
           input[readonly] {
-            background: var(--gray-50);
-            color: var(--gray-600);
+            background: light-dark(var(--gray-50), var(--gray-800));
+            color: var(--color-font-grey);
             cursor: not-allowed;
           }
         }
@@ -370,7 +373,8 @@
     border: none;
     border-radius: 12px;
     padding: 0;
-    box-shadow: 0 8px 32px rgb(0 0 0 / 15%);
+    box-shadow: var(--shadow-hover);
+    background: var(--color-background);
 
     &::backdrop {
       background: rgb(0 0 0 / 50%);
@@ -384,13 +388,13 @@
 
         h3 {
           margin: 0 0 var(--spacing-s) 0;
-          color: var(--gray-800);
+          color: var(--color-text);
           font-size: var(--heading-size-l);
         }
 
         p {
           margin: 0;
-          color: var(--gray-600);
+          color: var(--color-font-grey);
           font-size: var(--body-size-m);
         }
       }
@@ -407,28 +411,28 @@
           align-items: flex-start;
           gap: var(--spacing-xs);
           padding: var(--spacing-m);
-          background: var(--gray-25);
-          border: 2px solid var(--gray-300);
+          background: var(--layer-elevated);
+          border: 2px solid var(--color-border);
           border-radius: 8px;
           text-align: left;
           transition: all 0.2s ease;
           cursor: pointer;
 
           &:hover {
-            background: var(--blue-50);
+            background: light-dark(var(--blue-50), var(--gray-700));
             border-color: var(--blue-500);
             transform: translateY(-2px);
-            box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
+            box-shadow: var(--shadow-hover);
           }
 
           strong {
             font-size: 1.1rem;
-            color: var(--gray-900);
+            color: var(--color-text);
           }
 
           span {
             font-size: 0.875rem;
-            color: var(--gray-600);
+            color: var(--color-font-grey);
             font-weight: normal;
           }
         }


### PR DESCRIPTION
## Summary
- Update card backgrounds and borders for both themes
- Use theme-aware colors for form inputs and labels
- Update multilang sitemap variant for dark mode
- Update language list and dialogs for dark mode
- Subtle hover states matching light mode behavior

## Test plan
- [ ] Preview: https://dark-mode-sitemap-admin--helix-tools-website--adobe.aem.live/tools/sitemap-admin/index.html
- [ ] Verify sitemap cards display correctly in both themes
- [ ] Test multilang sitemap styling in dark mode


Made with [Cursor](https://cursor.com)