### PR TITLE
feat(site-query): add dark mode support

### DIFF
--- a/tools/site-query/styles.css
+++ b/tools/site-query/styles.css
@@ -77,7 +77,7 @@
 
 .site-query table tbody.error span.icon,
 .site-query table tbody.error p strong {
-  color: var(--red-900);
+  color: light-dark(var(--red-900), var(--red-400));
 }
 
 .site-query table a.edit-link {
@@ -85,7 +85,7 @@
 }
 
 .site-query table a.edit-link.disabled {
-  color: var(--red-900);
+  color: light-dark(var(--red-900), var(--red-400));
   font-weight: 500;
   text-decoration: none;
   cursor: default;


### PR DESCRIPTION
## Summary
- Update error text colors to use `light-dark()` for proper theme adaptation in dark mode

## Test plan
- [ ] Verify error states display with appropriate contrast in both light and dark modes

Preview: https://dark-mode-site-query--helix-tools-website--adobe.aem.live/tools/site-query/index.html

Made with [Cursor](https://cursor.com)