### PR TITLE
feat(powerscore): add dark mode support for all powerscore components

### DIFF
--- a/blocks/analyze/analyze.css
+++ b/blocks/analyze/analyze.css
@@ -94,7 +94,7 @@ main .analyze form {
       transition: grid-template-rows 0.5s 0s ease-in-out, border-bottom-width 0.2s 0s ease-in-out, border-right-width 0.1s 0.2s ease-in-out, border-left-width 0.1s 0.2s ease-in-out, border-top-width 0.2s 0.3s ease-in-out;
       padding: 1rem;
       margin: 0;
-      border: 0 groove #dfdfdf;
+      border: 0 groove light-dark(#dfdfdf, #404040);
       border-radius: 4px;
 
       legend {

--- a/blocks/availability/availability.css
+++ b/blocks/availability/availability.css
@@ -7,7 +7,10 @@
   aspect-ratio: 16 / 9;
   margin: 0 auto var(--spacing-s) auto;
   border-radius: var(--image-border-radius-l);
-  background: linear-gradient(135deg, var(--color-white), var(--color-accent-lightgreen-bg));
+  background: light-dark(
+    linear-gradient(135deg, var(--color-white), var(--color-accent-lightgreen-bg)),
+    linear-gradient(135deg, var(--gray-800), var(--gray-900))
+  );
 }
 
 .availability .tooltip-wrapper {
@@ -32,6 +35,8 @@
 
 .availability img,
 .availability svg {
+  --availability-shadow-opacity: light-dark(0.33, 0.6);
+
   display: block;
   max-width: 100%;
   height: auto;
@@ -39,7 +44,7 @@
   border-radius: var(--image-border-radius-xxl);
   background-color: var(--color-white);
   color: var(--bg-color-grey-2);
-  box-shadow: 0 4px 8px rgb(0 0 0 / 33%);
+  box-shadow: 0 4px 8px rgb(0 0 0 / var(--availability-shadow-opacity));
 }
 
 .availability svg circle {

--- a/blocks/data-element/data-element.css
+++ b/blocks/data-element/data-element.css
@@ -10,7 +10,7 @@ main .data-element {
         top: -1rem;
         margin: 0;
         background-color: var(--link-color);
-        color: white;
+        color: var(--color-white);
         border-radius: 4px;
         padding-inline: .5rem;
         text-wrap: nowrap;

--- a/blocks/power-score/power-score.css
+++ b/blocks/power-score/power-score.css
@@ -6,7 +6,7 @@ main .power-score {
 
   .power-score-inner {
     .power-score-diagram {
-      --diagram-border-color: black;
+      --diagram-border-color: light-dark(black, white);
 
       width: 300px;
       height: 300px;
@@ -26,7 +26,7 @@ main .power-score {
         display: flex;
         justify-content: center;
         align-items: center;
-        background-color: white;
+        background-color: var(--background-color);
         border: 2px solid var(--light-color);
         border-radius: 50%;
         aspect-ratio: 1;

--- a/blocks/results/results.css
+++ b/blocks/results/results.css
@@ -28,12 +28,15 @@ main .results {
     }
 
     .loading {
+      --loading-color-1: light-dark(#c9c9c9, #404040);
+      --loading-color-2: light-dark(#a4a4a4, #555);
+
       animation-duration: 1.8s;
       animation-fill-mode: forwards;
       animation-iteration-count: infinite;
       animation-name: loading;
       animation-timing-function: linear;
-      background: linear-gradient(to right, #c9c9c9 8%, #a4a4a4 38%, #c9c9c9 54%);
+      background: linear-gradient(to right, var(--loading-color-1) 8%, var(--loading-color-2) 38%, var(--loading-color-1) 54%);
       background-size: 1000px 640px;
     }
 

--- a/blocks/sub-score/sub-score.css
+++ b/blocks/sub-score/sub-score.css
@@ -36,7 +36,7 @@ main .sub-score {
     .meter {
       .outer {
         fill: none;
-        stroke: #BCBEC0;
+        stroke: light-dark(#bcbec0, #5a5c5e);
         stroke-width: 2;
       }
 

--- a/styles/powerscore-styles.css
+++ b/styles/powerscore-styles.css
@@ -2,13 +2,13 @@
   /* powerscore colors */
   --link-color: #035fe6;
   --link-hover-color: #136ff6;
-  --background-color: white;
-  --light-color: #eee;
-  --dark-color: #ccc;
-  --text-color: black;
-  --success-color: rgb(0 136 0);
-  --improve-color: rgb(255 170 51);
-  --error-color: rgb(217 48 37);
+  --background-color: light-dark(white, var(--gray-900));
+  --light-color: light-dark(#eee, var(--gray-700));
+  --dark-color: light-dark(#ccc, var(--gray-500));
+  --text-color: light-dark(black, var(--gray-100));
+  --success-color: light-dark(rgb(0 136 0), rgb(0 180 0));
+  --improve-color: light-dark(rgb(255 170 51), rgb(255 190 80));
+  --error-color: light-dark(rgb(217 48 37), rgb(240 80 70));
 }
 
 /* powerscore-specific styles scoped to main */


### PR DESCRIPTION
## Summary
- Update `powerscore-styles.css` root variables (`--background-color`, `--light-color`, `--dark-color`, `--text-color`, `--success-color`, `--improve-color`, `--error-color`) with `light-dark()` for theme adaptation
- Update `power-score` diagram border color and label background
- Update `sub-score` meter outer stroke color
- Update `analyze` advanced settings border color
- Update `results` loading animation gradient colors
- Update `availability` background gradient and shadow opacity
- Update `data-element` h3 text color to use theme variable

## Test plan
- [ ] Verify powerscore diagram displays correctly in both themes
- [ ] Check sub-score gauges have proper contrast in dark mode
- [ ] Test loading states for proper visibility
- [ ] Verify data element cards and labels are readable
- [ ] Check availability map has proper background and shadow

Preview: https://dark-mode-powerscore--helix-tools-website--adobe.aem.live/tools/powerscore/

Made with [Cursor](https://cursor.com)