### PR TITLE
fix(ci): enable PR comment posting in claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,13 +36,21 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Glob" "Grep" "LS"'
+          claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Glob" "Grep" "LS" "Skill"'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |
             Review PR #${{ github.event.pull_request.number }} using both approaches:
             1. Run the code-review plugin: /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
             2. Read and follow the local code-review skill at .claude/skills/code-review/SKILL.md for EDS-specific review criteria
+
+            IMPORTANT: After completing the review, post a summary comment on the PR using:
+            gh pr comment ${{ github.event.pull_request.number }} --body "YOUR_REVIEW"
+
+            The comment should include:
+            - Overall assessment (approve/request changes/comment)
+            - Key findings and recommendations
+            - Any blocking issues that must be addressed
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Add "Skill" to allowed tools (was being denied, blocking code-review plugin)
- Add instruction for Claude to post review summary as PR comment via `gh pr comment`

In automation mode, the claude-code-action writes output to the job summary only. This change ensures review findings are posted directly to the PR as a comment.

## Test plan
- [ ] Merge this PR
- [ ] Merge into the `cdn` branch to trigger a new review run
- [ ] Verify the review appears as a comment on the PR

Preview: https://fix-claude-review-pr-comments--helix-tools-website--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.ai/claude-code)