### PR TITLE
fix(ci): replace existing review comments instead of adding new ones

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,8 +44,13 @@ jobs:
             1. Run the code-review plugin: /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
             2. Read and follow the local code-review skill at .claude/skills/code-review/SKILL.md for EDS-specific review criteria
 
-            IMPORTANT: After completing the review, post a summary comment on the PR using:
-            gh pr comment ${{ github.event.pull_request.number }} --body "YOUR_REVIEW"
+            IMPORTANT: Before posting the review comment, delete any existing Claude review comments:
+            1. List existing comments: gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.body | contains("<!-- claude-code-review -->")) | .id'
+            2. Delete each found comment: gh api -X DELETE repos/${{ github.repository }}/issues/comments/{comment_id}
+
+            Then post the review summary using:
+            gh pr comment ${{ github.event.pull_request.number }} --body "<!-- claude-code-review -->
+            YOUR_REVIEW_CONTENT"
 
             The comment should include:
             - Overall assessment (approve/request changes/comment)


### PR DESCRIPTION
## Summary
- Adds HTML comment marker (`<!-- claude-code-review -->`) to identify Claude's review comments
- Instructs Claude to find and delete existing review comments before posting a new one
- Prevents multiple review comments from accumulating when PRs are updated

## Test plan
- [ ] Trigger a review on a PR
- [ ] Push an update to the same PR
- [ ] Verify old review comment is deleted and replaced with new one

Preview: https://update-review-prompt--helix-tools-website--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>