### PR TITLE
fix: 404 page in dark mode

### DIFF
--- a/404.html
+++ b/404.html
@@ -49,6 +49,7 @@
 
     main.error .error-number text {
       font-family: var(--fixed-font-family);
+      fill: currentcolor;
     }
   </style>
   <link rel="stylesheet" href="/styles/lazy-styles.css">


### PR DESCRIPTION
Fixes 404 page in dark mode.

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/404
- After: https://404-dark--helix-tools-website--adobe.aem.live/404
