### PR TITLE
chore: allow for broader legal hostname match

### DIFF
--- a/tools/cdn-setup/cdn-setup.js
+++ b/tools/cdn-setup/cdn-setup.js
@@ -381,7 +381,7 @@ async function saveConfig() {
     return;
   }
 
-  // DNS-compatible: labels 1–63 chars, alphanumeric and hyphen, no leading/trailing hyphen; total ≤253
+  // DNS: labels 1-63 chars, [a-z0-9-] no leading/trailing hyphen, total ≤253
   const dnsLabel = '[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?';
   const hostPattern = new RegExp(`^(${dnsLabel})(\\.(${dnsLabel}))*$`);
   if (!host.value || host.value.length > 253 || !hostPattern.test(host.value)) {


### PR DESCRIPTION
allows for non `www.` hostnames

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/cdn-setup/index.html
- After: https://fix-broader-hostname--helix-tools-website--adobe.aem.live/tools/cdn-setup/index.html

