### PR TITLE
fix(form): support Type "button" for non-submitting form buttons

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -52,10 +52,12 @@ async function submitForm(form) {
 function createButton(fd) {
   const button = document.createElement('button');
   button.textContent = fd.Label;
+  button.type = fd.Type;
   button.classList.add('button');
   if (fd.Type === 'submit') {
     button.addEventListener('click', async (event) => {
       const form = button.closest('form');
+      if (!form) return;
       if (fd.Placeholder) form.dataset.action = fd.Placeholder;
       if (form.checkValidity()) {
         event.preventDefault();
@@ -165,6 +167,7 @@ export async function createForm(formURL) {
         fieldWrapper.append(createLabel(fd));
         fieldWrapper.append(createTextArea(fd));
         break;
+      case 'button':
       case 'submit':
         fieldWrapper.append(createButton(fd));
         break;

--- a/blocks/svg-doctor/svg-doctor.css
+++ b/blocks/svg-doctor/svg-doctor.css
@@ -28,21 +28,21 @@
   visibility: hidden;
 }
 
-.svg-doctor form label {
+.svg-doctor .viewbox label {
   color: black;
   transition: color .3s;
 }
 
-.svg-doctor form .viewbox[data-mode='dark'] label {
+.svg-doctor .viewbox[data-mode='dark'] label {
   color: white;
 }
 
-.svg-doctor form label p {
+.svg-doctor .viewbox label p {
   color: inherit;
   text-align: center;
 }
 
-.svg-doctor form label span + p {
+.svg-doctor .viewbox label span + p {
   margin-top: .5em;
 }
 

--- a/blocks/svg-doctor/svg-doctor.js
+++ b/blocks/svg-doctor/svg-doctor.js
@@ -420,7 +420,7 @@ function resetForm(viewBox) {
       [...palette.children].forEach((swatch) => swatch.remove());
     }
   }
-  const specs = block.querySelector('div.form.specs');
+  const specs = block.querySelector('.form.specs');
   if (specs) {
     specs.setAttribute('aria-hidden', true);
   }
@@ -444,18 +444,17 @@ function disableForm(block) {
   if (controls) {
     controls.removeAttribute('aria-hidden');
   }
-  const specs = block.querySelector('div.form.specs');
+  const specs = block.querySelector('.form.specs');
   if (specs) {
     specs.removeAttribute('aria-hidden');
   }
 }
 
 async function buildForm(url) {
-  const doctor = createTag('div', { class: 'form specs' });
   const form = await createForm(url);
+  form.classList.add('form', 'specs');
   await loadCSS(`${window.hlx.codeBasePath}/blocks/form/form.css`);
-  doctor.append(...form.children);
-  return doctor;
+  return form;
 }
 
 function buildControlButton(specs, viewBox) {


### PR DESCRIPTION
## Summary

The form block only supported `Type: "submit"` for buttons, always wiring up the generic submit-and-redirect handler. This made it impossible for callers like svg-doctor to use `createForm()` without inheriting submit behavior — svg-doctor worked around this by extracting form children into a `<div>`, which caused a `closest('form')` null dereference (~10 occurrences/week).

Aligns with the block collection's `buildButton()` pattern:
- Adds `"button"` as a recognized `Type` that creates a styled button without a submit handler
- Sets `button.type` on the DOM element so the native type matches the field definition
- Adds null guard on `closest('form')` as defensive measure
- svg-doctor's `buildForm()` returns the `<form>` element directly instead of extracting children into a wrapper `<div>`
- Scopes viewbox label color rules to `.viewbox label` to prevent dark mode bleed into spec form labels

### Required CMS change

button type in https://main--helix-tools-website--adobe.aem.page/tools/svg-doctor/svg-doctor.json changed to type button instead of submit, this needs to be published when merging.

fix #233

## Test plan

- [x] Open https://fix-form-null-check--helix-tools-website--adobe.aem.page/tools/svg-doctor/
- [x] Upload an SVG and click the download button — should not throw a TypeError
- [x] After CMS change: verify Download triggers client-side download without POST or page navigation
- [x] Verify spec form labels (Icon Title, etc.) are readable in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)