### PR TITLE
chore: bump stylelint to 17.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "eslint": "8.57.1",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.32.0",
-        "stylelint": "17.0.0",
+        "stylelint": "17.3.0",
         "stylelint-config-standard": "40.0.0"
       }
     },
@@ -357,6 +357,30 @@
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
@@ -4434,9 +4458,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.0.0.tgz",
-      "integrity": "sha512-saMZ2mqdQre4AfouxcbTdpVglDRcROb4MIucKHvgsDb/0IX7ODhcaz+EOIyfxAsm8Zjl/7j4hJj6MgIYYM8Xwg==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.3.0.tgz",
+      "integrity": "sha512-1POV91lcEMhj6SLVaOeA0KlS9yattS+qq+cyWqP/nYzWco7K5jznpGH1ExngvPlTM9QF1Kjd2bmuzJu9TH2OcA==",
       "dev": true,
       "funding": [
         {
@@ -4450,8 +4474,9 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.25",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
         "@csstools/css-tokenizer": "^4.0.0",
         "@csstools/media-query-list-parser": "^5.0.0",
         "@csstools/selector-resolve-nested": "^4.0.0",
@@ -4464,7 +4489,7 @@
         "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^11.1.1",
+        "file-entry-cache": "^11.1.2",
         "global-modules": "^2.0.0",
         "globby": "^16.1.0",
         "globjoin": "^0.1.4",
@@ -4483,7 +4508,7 @@
         "postcss-safe-parser": "^7.0.1",
         "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0",
-        "string-width": "^8.1.0",
+        "string-width": "^8.1.1",
         "supports-hyperlinks": "^4.4.0",
         "svg-tags": "^1.0.0",
         "table": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "8.57.1",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-import": "2.32.0",
-    "stylelint": "17.0.0",
+    "stylelint": "17.3.0",
     "stylelint-config-standard": "40.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps stylelint from 17.0.0 to 17.3.0 to align with [aem-boilerplate](https://github.com/adobe/aem-boilerplate)

## Test plan
- [x] `npm run lint` passes cleanly

https://chore-bump-stylelint--helix-tools-website--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>