### PR TITLE
chore: align renovate config with aem-boilerplate

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,8 +1,16 @@
 {
   "extends": ["config:recommended"],
-  "packageRules": [{
+  "packageRules": [
+    {
       "matchDepTypes": ["devDependencies"],
       "labels": ["ignore-psi-check"],
-      "automerge": true
-  }]
+      "automerge": true,
+      "ignoreTests": false
+    },
+    {
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "^8.0.0",
+      "description": "Pin ESLint to v8 until airbnb-base supports v9+"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Require CI checks to pass before automerging (`ignoreTests: false`) — prevents broken builds from being merged automatically
- Pin ESLint to `^8.0.0` until `airbnb-base` supports v9+ (see https://github.com/airbnb/javascript/issues/2961)

Aligns with https://github.com/adobe/aem-boilerplate/pull/591

## Test plan
- [x] Config-only change, no code impact

https://chore-align-renovate-config--helix-tools-website--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>