### PR TITLE
chore: update code review skill to respect both .page and .live urls

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -52,7 +52,7 @@ gh pr diff <PR-number>
 ## Review Criteria
 
 **PR Structure (PR mode only):**
-- Preview URL: `https://{branch}--helix-tools-website--adobe.aem.page/{path}`
+- Preview URL: `https://{branch}--helix-tools-website--adobe.aem.page/{path}` or `https://{branch}--helix-tools-website--adobe.aem.live/{path}` (both `.aem.page` and `.aem.live` are accepted)
 - Clear description of what changed and why
 
 **JavaScript:**

--- a/.claude/skills/code-review/resources/review-checklist.md
+++ b/.claude/skills/code-review/resources/review-checklist.md
@@ -17,9 +17,18 @@ Detailed checklist for reviewing Edge Delivery Services pull requests. Use this 
 
 ### Preview URL Format
 
+Both `.aem.page` and `.aem.live` domains are accepted:
+
 ```
 Before: https://main--{repo}--{owner}.aem.page/{path-to-test-content}
 After: https://{branch}--{repo}--{owner}.aem.page/{path-to-test-content}
+```
+
+or
+
+```
+Before: https://main--{repo}--{owner}.aem.live/{path-to-test-content}
+After: https://{branch}--{repo}--{owner}.aem.live/{path-to-test-content}
 ```
 
 ### PR Description Template
@@ -32,8 +41,8 @@ After: https://{branch}--{repo}--{owner}.aem.page/{path-to-test-content}
 Fix #<issue-number>
 
 ## Test URLs
-- Before: https://main--{repo}--{owner}.aem.page/{path}
-- After: https://{branch}--{repo}--{owner}.aem.page/{path}
+- Before: https://main--{repo}--{owner}.aem.live/{path}
+- After: https://{branch}--{repo}--{owner}.aem.live/{path}
 
 ## Types of Changes
 - [ ] Bug fix


### PR DESCRIPTION
The code review skill expects a .page URL, but the PR template has .live

Updates the code review skill to support both.

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/
- After: https://claude-review--helix-tools-website--adobe.aem.live/
