### PR TITLE
fix(recent-tools): skip logging visits on 404 error pages

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,6 +1,6 @@
 // Record tool visits for recent tools on landing page
 const path = window.location.pathname;
-if (path.startsWith('/tools/')) {
+if (path.startsWith('/tools/') && !window.isErrorPage) {
   try {
     const visits = JSON.parse(localStorage.getItem('aem-tool-visits') || '[]');
     const filtered = visits.filter((v) => v.path !== path);


### PR DESCRIPTION
## Summary
- Prevents 404 error pages from being recorded in the recent tools list
- Checks `window.isErrorPage` (set by `404.html`) before writing to localStorage

## Test plan
- [ ] Visit a valid tool page → verify it still appears in recent tools
- [ ] Visit a non-existent `/tools/...` URL (triggering 404) → verify it does **not** appear in recent tools

Preview: https://fix-recent-visits-skip-404--helix-tools-website--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>