### PR TITLE
fix(sitemap-admin): dialog cleanup, accessibility, and UX fixes

### DIFF
--- a/tools/sitemap-admin/index.html
+++ b/tools/sitemap-admin/index.html
@@ -84,10 +84,10 @@
     </li>
   </template>
   <template id="sitemap-details-dialog-template">
-    <dialog class="sitemap-details">
+    <dialog class="sitemap-details" aria-labelledby="sitemap-details-dialog-title">
       <div class="sitemap-details-content">
         <div class="sitemap-details-header">
-          <h3>Edit Sitemap</h3>
+          <h3 id="sitemap-details-dialog-title">Edit Sitemap</h3>
         </div>
         <div class="sitemap-details-body">
           <form>
@@ -163,10 +163,10 @@
     </li>
   </template>
   <template id="sitemap-multilang-dialog-template">
-    <dialog class="sitemap-details multilang-dialog">
+    <dialog class="sitemap-details multilang-dialog" aria-labelledby="sitemap-multilang-dialog-title">
       <div class="sitemap-details-content">
         <div class="sitemap-details-header">
-          <h3>Edit Multi-Language Sitemap</h3>
+          <h3 id="sitemap-multilang-dialog-title">Edit Multi-Language Sitemap</h3>
           <p>Edit top-level settings. Use the language buttons to add or edit individual languages.</p>
         </div>
         <div class="sitemap-details-body">
@@ -220,10 +220,10 @@
     </div>
   </template>
   <template id="language-edit-dialog-template">
-    <dialog class="language-edit-dialog">
+    <dialog class="language-edit-dialog" aria-labelledby="language-edit-dialog-title">
       <div class="language-edit-content">
         <div class="language-edit-header">
-          <h3>Edit Language Configuration</h3>
+          <h3 id="language-edit-dialog-title">Edit Language Configuration</h3>
         </div>
         <div class="language-edit-body">
           <form>
@@ -261,10 +261,10 @@
     </dialog>
   </template>
   <template id="sitemap-type-dialog-template">
-    <dialog class="sitemap-type-dialog">
+    <dialog class="sitemap-type-dialog" aria-labelledby="sitemap-type-dialog-title">
       <div class="sitemap-type-content">
         <div class="sitemap-type-header">
-          <h3>Choose Sitemap Type</h3>
+          <h3 id="sitemap-type-dialog-title">Choose Sitemap Type</h3>
           <p>Select the type of sitemap you want to create:</p>
         </div>
         <div class="sitemap-type-options">
@@ -277,7 +277,7 @@
             <span>Multiple languages with hreflang support</span>
           </button>
         </div>
-        <div class="button-area">
+        <div class="button-area sitemap-type-button-area">
           <p class="button-wrapper">
             <button type="button" id="cancel-type-btn" class="button outline">Cancel</button>
           </p>

--- a/tools/sitemap-admin/sitemap-admin.css
+++ b/tools/sitemap-admin/sitemap-admin.css
@@ -438,7 +438,7 @@
         }
       }
 
-      .sitemap-type-content .button-area {
+      .sitemap-type-button-area {
         display: flex;
         justify-content: center;
         margin-top: var(--spacing-m);

--- a/tools/sitemap-admin/sitemap-admin.js
+++ b/tools/sitemap-admin/sitemap-admin.js
@@ -40,7 +40,7 @@ function displaySitemapDetails(sitemapName, sitemapDef, newSitemap = false) {
   const isMultiLang = isMultiLanguageSitemap(sitemapDef);
   const templateId = isMultiLang ? '#sitemap-multilang-dialog-template' : '#sitemap-details-dialog-template';
   document.body.append(document.querySelector(templateId).content.cloneNode(true));
-  const sitemapDetails = document.body.querySelector('dialog.sitemap-details:last-of-type');
+  const sitemapDetails = document.querySelector('dialog.sitemap-details');
   registerDialogCleanup(sitemapDetails);
 
   sitemapDetails.querySelector('#sitemap-name').value = sitemapName;
@@ -156,7 +156,7 @@ function displaySitemapDetails(sitemapName, sitemapDef, newSitemap = false) {
 
 function showTypeSelectionDialog() {
   document.body.append(document.querySelector('#sitemap-type-dialog-template').content.cloneNode(true));
-  const typeDialog = document.body.querySelector('dialog.sitemap-type-dialog:last-of-type');
+  const typeDialog = document.querySelector('dialog.sitemap-type-dialog');
   registerDialogCleanup(typeDialog);
   typeDialog.showModal();
 
@@ -197,7 +197,7 @@ function showTypeSelectionDialog() {
 
 function displayLanguageEditDialog(sitemapName, langCode, langDef, isNew = false) {
   document.body.append(document.querySelector('#language-edit-dialog-template').content.cloneNode(true));
-  const langDialog = document.body.querySelector('dialog.language-edit-dialog:last-of-type');
+  const langDialog = document.querySelector('dialog.language-edit-dialog');
   registerDialogCleanup(langDialog);
 
   const langCodeInput = langDialog.querySelector('#lang-code');

--- a/tools/sitemap-admin/sitemap-admin.js
+++ b/tools/sitemap-admin/sitemap-admin.js
@@ -12,6 +12,26 @@ const addSitemapButton = document.getElementById('add-sitemap');
 let loadedSitemaps;
 let YAML;
 
+function cleanupDialog(dialog) {
+  dialog.close();
+  dialog.remove();
+}
+
+function registerDialogCleanup(dialog) {
+  dialog.addEventListener('close', () => {
+    dialog.remove();
+  });
+
+  dialog.addEventListener('cancel', () => {
+    dialog.remove();
+  });
+}
+
+async function ensureYaml() {
+  // eslint-disable-next-line import/no-unresolved
+  YAML = YAML || await import('https://unpkg.com/yaml@2.8.1/browser/index.js');
+}
+
 function isMultiLanguageSitemap(sitemapDef) {
   return sitemapDef?.languages !== undefined;
 }
@@ -20,7 +40,8 @@ function displaySitemapDetails(sitemapName, sitemapDef, newSitemap = false) {
   const isMultiLang = isMultiLanguageSitemap(sitemapDef);
   const templateId = isMultiLang ? '#sitemap-multilang-dialog-template' : '#sitemap-details-dialog-template';
   document.body.append(document.querySelector(templateId).content.cloneNode(true));
-  const sitemapDetails = document.querySelector('dialog.sitemap-details');
+  const sitemapDetails = document.body.querySelector('dialog.sitemap-details:last-of-type');
+  registerDialogCleanup(sitemapDetails);
 
   sitemapDetails.querySelector('#sitemap-name').value = sitemapName;
   if (!newSitemap) {
@@ -47,8 +68,7 @@ function displaySitemapDetails(sitemapName, sitemapDef, newSitemap = false) {
     const backButton = backButtonWrapper.querySelector('#back-sitemap');
     backButton.addEventListener('click', (e) => {
       e.preventDefault();
-      sitemapDetails.close();
-      sitemapDetails.remove();
+      cleanupDialog(sitemapDetails);
       // eslint-disable-next-line no-use-before-define
       showTypeSelectionDialog();
     });
@@ -107,8 +127,7 @@ function displaySitemapDetails(sitemapName, sitemapDef, newSitemap = false) {
     logResponse(consoleBlock, resp.status, ['POST', `https://admin.hlx.page/config/${org.value}/sites/${site.value}/content/sitemap.yaml`, resp.headers.get('x-error') || '']);
 
     if (resp.ok) {
-      sitemapDetails.close();
-      sitemapDetails.remove();
+      cleanupDialog(sitemapDetails);
 
       const sitemapsList = document.getElementById('sitemaps-list');
       sitemapsList.innerHTML = '';
@@ -121,8 +140,7 @@ function displaySitemapDetails(sitemapName, sitemapDef, newSitemap = false) {
 
   cancel.addEventListener('click', (e) => {
     e.preventDefault();
-    sitemapDetails.close();
-    sitemapDetails.remove();
+    cleanupDialog(sitemapDetails);
   });
 
   sitemapDetails.addEventListener('click', (e) => {
@@ -131,21 +149,20 @@ function displaySitemapDetails(sitemapName, sitemapDef, newSitemap = false) {
     } = sitemapDetails.getBoundingClientRect();
     const { clientX, clientY } = e;
     if (clientX < left || clientX > right || clientY < top || clientY > bottom) {
-      sitemapDetails.close();
-      sitemapDetails.remove();
+      cleanupDialog(sitemapDetails);
     }
   });
 }
 
 function showTypeSelectionDialog() {
   document.body.append(document.querySelector('#sitemap-type-dialog-template').content.cloneNode(true));
-  const typeDialog = document.querySelector('dialog.sitemap-type-dialog');
+  const typeDialog = document.body.querySelector('dialog.sitemap-type-dialog:last-of-type');
+  registerDialogCleanup(typeDialog);
   typeDialog.showModal();
 
   typeDialog.querySelector('#simple-sitemap-btn').addEventListener('click', (e) => {
     e.preventDefault();
-    typeDialog.close();
-    typeDialog.remove();
+    cleanupDialog(typeDialog);
     displaySitemapDetails('', {
       source: '/query-index.json',
       destination: '/sitemap.xml',
@@ -155,8 +172,7 @@ function showTypeSelectionDialog() {
 
   typeDialog.querySelector('#multilang-sitemap-btn').addEventListener('click', (e) => {
     e.preventDefault();
-    typeDialog.close();
-    typeDialog.remove();
+    cleanupDialog(typeDialog);
     displaySitemapDetails('', {
       lastmod: 'YYYY-MM-DD',
       languages: {},
@@ -165,8 +181,7 @@ function showTypeSelectionDialog() {
 
   typeDialog.querySelector('#cancel-type-btn').addEventListener('click', (e) => {
     e.preventDefault();
-    typeDialog.close();
-    typeDialog.remove();
+    cleanupDialog(typeDialog);
   });
 
   typeDialog.addEventListener('click', (e) => {
@@ -175,15 +190,15 @@ function showTypeSelectionDialog() {
     } = typeDialog.getBoundingClientRect();
     const { clientX, clientY } = e;
     if (clientX < left || clientX > right || clientY < top || clientY > bottom) {
-      typeDialog.close();
-      typeDialog.remove();
+      cleanupDialog(typeDialog);
     }
   });
 }
 
 function displayLanguageEditDialog(sitemapName, langCode, langDef, isNew = false) {
   document.body.append(document.querySelector('#language-edit-dialog-template').content.cloneNode(true));
-  const langDialog = document.querySelector('dialog.language-edit-dialog');
+  const langDialog = document.body.querySelector('dialog.language-edit-dialog:last-of-type');
+  registerDialogCleanup(langDialog);
 
   const langCodeInput = langDialog.querySelector('#lang-code');
   langCodeInput.value = langCode;
@@ -253,8 +268,7 @@ function displayLanguageEditDialog(sitemapName, langCode, langDef, isNew = false
     logResponse(consoleBlock, resp.status, ['POST', `https://admin.hlx.page/config/${org.value}/sites/${site.value}/content/sitemap.yaml`, resp.headers.get('x-error') || '']);
 
     if (resp.ok) {
-      langDialog.close();
-      langDialog.remove();
+      cleanupDialog(langDialog);
 
       const sitemapsList = document.getElementById('sitemaps-list');
       sitemapsList.innerHTML = '';
@@ -267,8 +281,7 @@ function displayLanguageEditDialog(sitemapName, langCode, langDef, isNew = false
 
   cancel.addEventListener('click', (e) => {
     e.preventDefault();
-    langDialog.close();
-    langDialog.remove();
+    cleanupDialog(langDialog);
   });
 
   langDialog.addEventListener('click', (e) => {
@@ -277,8 +290,7 @@ function displayLanguageEditDialog(sitemapName, langCode, langDef, isNew = false
     } = langDialog.getBoundingClientRect();
     const { clientX, clientY } = e;
     if (clientX < left || clientX > right || clientY < top || clientY > bottom) {
-      langDialog.close();
-      langDialog.remove();
+      cleanupDialog(langDialog);
     }
   });
 }
@@ -316,11 +328,11 @@ async function generateSitemap(destination) {
   const sitemapUrl = `https://admin.hlx.page/sitemap/${org.value}/${site.value}/main${destination}`;
   const resp = await fetch(sitemapUrl, { method: 'POST' });
 
-  if (resp.ok) {
+  if (resp.status === 204) {
+    logResponse(consoleBlock, 204, ['POST', sitemapUrl, 'Path is not a destination for any configured sitemap']);
+  } else if (resp.ok) {
     const result = await resp.json();
     logResponse(consoleBlock, 200, ['POST', sitemapUrl, `Generated sitemap(s): ${result.paths?.join(', ') || destination}`]);
-  } else if (resp.status === 204) {
-    logResponse(consoleBlock, 204, ['POST', sitemapUrl, 'Path is not a destination for any configured sitemap']);
   } else {
     logResponse(consoleBlock, resp.status, ['POST', sitemapUrl, resp.headers.get('x-error') || '']);
   }
@@ -368,13 +380,13 @@ function populateSitemaps(sitemaps) {
     sitemapItem.querySelector('.sitemap-name').textContent = name;
 
     if (isMultiLang) {
-      // Display multi-language sitemap info
+      // Render top-level multilang metadata separately from per-language settings.
       const languageCount = Object.keys(sitemapDef.languages).length;
       sitemapItem.querySelector('.sitemap-attribute-value-languages').textContent = `${languageCount} language${languageCount !== 1 ? 's' : ''}`;
       sitemapItem.querySelector('.sitemap-attribute-value-origin').textContent = sitemapDef.origin || 'n/a';
       sitemapItem.querySelector('.sitemap-attribute-value-default').textContent = sitemapDef.default || 'n/a';
 
-      // Show list of languages with edit/remove buttons
+      // Each language row gets its own controls so authors can update entries in place.
       const languagesList = sitemapItem.querySelector('.languages-list');
       Object.entries(sitemapDef.languages).forEach(([langCode, langDef]) => {
         languagesList.append(document.querySelector('#language-item-template').content.cloneNode(true));
@@ -383,26 +395,23 @@ function populateSitemaps(sitemaps) {
         langItem.querySelector('.lang-code').textContent = langCode;
         langItem.querySelector('.lang-destination').textContent = langDef.destination;
 
-        // Edit language button
         langItem.querySelector('.edit-language-btn').addEventListener('click', (e) => {
           e.preventDefault();
           displayLanguageEditDialog(name, langCode, langDef, false);
         });
 
-        // Remove language button
         langItem.querySelector('.remove-language-btn').addEventListener('click', async (e) => {
           e.preventDefault();
           await removeLanguage(name, langCode);
         });
       });
 
-      // Add language button
       sitemapItem.querySelector('.add-language-btn').addEventListener('click', (e) => {
         e.preventDefault();
         displayLanguageEditDialog(name, '', {}, true);
       });
     } else {
-      // Display simple sitemap info
+      // Simple sitemaps expose a single source/destination pair on the card.
       sitemapItem.querySelector('.sitemap-attribute-value-source').textContent = sitemapDef.source || 'n/a';
       sitemapItem.querySelector('.sitemap-attribute-value-destination').textContent = sitemapDef.destination || 'n/a';
       sitemapItem.querySelector('.sitemap-attribute-value-origin').textContent = sitemapDef.origin || 'n/a';
@@ -436,10 +445,12 @@ function populateSitemaps(sitemaps) {
         return;
       }
 
-      await generateSitemap(destPath);
-
-      btn.disabled = false;
-      btn.textContent = 'Generate';
+      try {
+        await generateSitemap(destPath);
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Generate';
+      }
     });
 
     sitemapItem.querySelector('.remove-sitemap-btn').addEventListener('click', async (e) => {
@@ -473,8 +484,7 @@ async function init() {
 
     if (resp.ok) {
       updateConfig();
-      // eslint-disable-next-line import/no-unresolved
-      YAML = YAML || await import('https://unpkg.com/yaml@2.8.1/browser/index.js');
+      await ensureYaml();
 
       const yamlText = await resp.text();
       loadedSitemaps = YAML.parse(yamlText);
@@ -483,8 +493,7 @@ async function init() {
       addSitemapButton.disabled = false;
     } else if (resp.status === 404) {
       updateConfig();
-      // eslint-disable-next-line import/no-unresolved
-      YAML = YAML || await import('https://unpkg.com/yaml@2.8.1/browser/index.js');
+      await ensureYaml();
 
       loadedSitemaps = { version: 1, sitemaps: {} };
       populateSitemaps({});
@@ -493,6 +502,10 @@ async function init() {
       ensureLogin(org.value, site.value);
     }
   });
+
+  if (org.value && site.value) {
+    adminForm.requestSubmit();
+  }
 }
 
 registerToolReady(init());


### PR DESCRIPTION
## Summary

Part 1 of 2 replacing #252, which combined cleanup/fixes with new features. This PR contains only the fixes and cleanup; the sitemap index definition viewer will follow in a separate PR.

- Extract `cleanupDialog`/`registerDialogCleanup` helpers so dialogs are properly removed on close, cancel, and Escape
- Add `aria-labelledby` to all dialog templates for screen reader support
- Fix 204 response handling in `generateSitemap` to avoid calling `resp.json()` on empty body
- Wrap generate button reset in `try/finally` so it recovers on errors
- Deduplicate YAML import into `ensureYaml()` helper
- Fix CSS specificity for type dialog button area
- Auto-submit form when `org`/`site` query params are present

Preview: https://fix-sitemap-admin-cleanup--helix-tools-website--adobe.aem.page/tools/sitemap-admin/index.html

## Test plan
- [x] Dismiss each sitemap dialog via Escape, then reopen it and verify a fresh dialog opens correctly
- [x] Dismiss each dialog via cancel button and backdrop click, then verify reopening still works
- [x] Verify all dialogs expose the correct accessible name from their headings (check with screen reader or dev tools)
- [x] Verify the type-selection dialog cancel area is laid out correctly
- [x] Generate a sitemap for a configured destination and verify success
- [x] Generate a sitemap for a path that is not a configured destination and verify the 204 response is handled gracefully without leaving the button disabled
- [x] Load the page with `?org=<org>&site=<site>` and verify the form auto-submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>