### PR TITLE
chore: remove experimental label from site-admin and user-admin

### DIFF
--- a/tools/site-admin/index.html
+++ b/tools/site-admin/index.html
@@ -9,7 +9,6 @@
   >
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="lab" content="true">
   <title>Site Admin</title>
   <script nonce="aem" src="/scripts/aem.js" type="module"></script>
   <script nonce="aem" src="/scripts/scripts.js" type="module"></script>

--- a/tools/user-admin/index.html
+++ b/tools/user-admin/index.html
@@ -9,7 +9,6 @@
   >
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="lab" content="true">
   <title>User Admin</title>
   <script nonce="aem" src="/scripts/aem.js" type="module"></script>
   <script nonce="aem" src="/scripts/scripts.js" type="module"></script>


### PR DESCRIPTION
## Summary
- Remove `<meta name="lab" content="true">` from site-admin and user-admin tools
- Both tools have shown consistent usage in RUM, justifying promotion from experimental status

RUM data: https://tools.aem.live/tools/optel/explorer/explorer.html?domain=tools.aem.live&filter=&view=month&domainkey=

## Preview
- https://promote-tools--helix-tools-website--adobe.aem.page/tools/site-admin/index.html
- https://promote-tools--helix-tools-website--adobe.aem.page/tools/user-admin/index.html

## Test plan
- [ ] Verify site-admin no longer shows experimental label
- [ ] Verify user-admin no longer shows experimental label
- [ ] Confirm both tools still function correctly

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)