### PR TITLE
fix(optel): saved reports should not be visible when domain is missing

### DIFF
--- a/blocks/ai-optel-report-generator/reports/da-upload.js
+++ b/blocks/ai-optel-report-generator/reports/da-upload.js
@@ -219,10 +219,11 @@ function mapFolderItemsToReports(items, folder, domain = null) {
 /** List folder contents via CF Worker */
 async function listFolder(path) {
   try {
+    const domainkey = new URL(window.location.href).searchParams.get('domainkey') || '';
     const res = await fetch(DA_CONFIG.WORKER_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'list', path }),
+      body: JSON.stringify({ action: 'list', path, domainkey }),
     });
     if (!res.ok) return [];
     const data = await res.json();

--- a/blocks/ai-optel-report-generator/reports/report-state.js
+++ b/blocks/ai-optel-report-generator/reports/report-state.js
@@ -29,6 +29,7 @@ const filterByWeek = (reports) => {
 export async function getSavedReports() {
   try {
     const domain = getCurrentAnalyzedUrl();
+    if (!domain) return [];
     return await fetchReportsFromDA(domain);
   } catch (err) {
     if (err.message?.includes('Failed to fetch') || err.message?.includes('CORS')) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/optel/oversight/explorer.html
- After: https://optel-fix--helix-tools-website--adobe.aem.live/tools/optel/oversight/explorer.html
