### PR TITLE
fix(optel): pass domain name for check on listing saved OpTel Reports

### DIFF
--- a/blocks/ai-optel-report-generator/reports/da-upload.js
+++ b/blocks/ai-optel-report-generator/reports/da-upload.js
@@ -220,10 +220,13 @@ function mapFolderItemsToReports(items, folder, domain = null) {
 async function listFolder(path) {
   try {
     const domainkey = new URL(window.location.href).searchParams.get('domainkey') || '';
+    const domain = getCurrentAnalyzedUrl();
     const res = await fetch(DA_CONFIG.WORKER_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'list', path, domainkey }),
+      body: JSON.stringify({
+        action: 'list', path, domainkey, domain,
+      }),
     });
     if (!res.ok) return [];
     const data = await res.json();


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/optel/oversight/explorer.html?domain=www.adobe.com&view=month&domainkey=abc
- After: https://optel-reports--helix-tools-website--adobe.aem.live/tools/optel/oversight/explorer.html?domain=www.adobe.com&view=month&domainkey=abc

For the fix to not list saved reports when domain key for the domain is incorrect.