### PR TITLE
feat(utils): add admin-fetch and tool-config utilities

### DIFF
--- a/utils/admin-fetch.js
+++ b/utils/admin-fetch.js
@@ -1,0 +1,25 @@
+const ADMIN_API_BASE = 'https://admin.hlx.page';
+
+/**
+ * Creates an admin API fetch function bound to an optional response logger.
+ * @param {Function} [logFn] - Optional (status, [method, url, error]) => void
+ * @returns {Function} adminFetch(pathTemplate, params, options)
+ *   pathTemplate: path with {org}, {site}, etc. placeholders
+ *   params: object of placeholder values
+ *   options: standard fetch options
+ */
+export default function createAdminFetch(logFn) {
+  return async function adminFetch(pathTemplate, params = {}, options = {}) {
+    const path = pathTemplate.replace(
+      /\{(\w+)\}/g,
+      (_, key) => encodeURIComponent(params[key] ?? ''),
+    );
+    const url = `${ADMIN_API_BASE}${path}`;
+    const method = options.method || 'GET';
+    const resp = await fetch(url, options);
+    if (logFn) {
+      logFn(resp.status, [method, url, resp.headers.get('x-error') || '']);
+    }
+    return resp;
+  };
+}

--- a/utils/tool-config.js
+++ b/utils/tool-config.js
@@ -1,0 +1,120 @@
+import { messageSidekick, NO_SIDEKICK } from './sidekick.js';
+import { logResponse } from '../blocks/console/console.js';
+
+const LOGIN_TIMEOUT = 120000;
+// Brief settle delay after login before tools make API calls, to let the
+// sidekick propagate the auth token.
+const POST_LOGIN_SETTLE = 500;
+const settle = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+// One pending login per org so concurrent onConfigReady calls share the result.
+const pendingLogins = new Map();
+
+async function ensureAuth(org, site) {
+  const authInfo = await messageSidekick({ action: 'getAuthInfo' });
+
+  if (authInfo === NO_SIDEKICK) {
+    // eslint-disable-next-line no-alert
+    if (window.confirm('AEM Sidekick is required to sign in. Install now?')) {
+      window.open(
+        'https://chromewebstore.google.com/detail/aem-sidekick/igkmdomcgoebiipaifhmpfjhbjccggml',
+        '_blank',
+      );
+    }
+    return false;
+  }
+
+  if (Array.isArray(authInfo) && authInfo.includes(org)) return true;
+
+  if (pendingLogins.has(org)) return pendingLogins.get(org);
+
+  const loginPromise = (async () => {
+    try {
+      let loginSite = site;
+      if (!loginSite) {
+        const sites = await messageSidekick({ action: 'getSites' });
+        if (Array.isArray(sites)) {
+          const match = sites.find((s) => s.org === org);
+          if (match) loginSite = match.site || match.repo || '';
+        }
+      }
+      if (!loginSite) return false;
+
+      const success = await messageSidekick(
+        { action: 'login', org, site: loginSite },
+        null,
+        LOGIN_TIMEOUT,
+      );
+      if (success) await settle(POST_LOGIN_SETTLE);
+      return !!success;
+    } finally {
+      pendingLogins.delete(org);
+    }
+  })();
+
+  pendingLogins.set(org, loginPromise);
+  return loginPromise;
+}
+
+/**
+ * Returns the current org and site from URL search params.
+ * @returns {{ org: string, site: string }}
+ */
+export function getCurrentConfig() {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    org: params.get('org') || '',
+    site: params.get('site') || '',
+  };
+}
+
+/**
+ * Registers a callback that fires when an org/site config is ready.
+ *
+ * Fires immediately if URL params already contain an org, then again on every
+ * config-update event dispatched by the site picker.
+ *
+ * @param {Function} callback - Called with { org, site, authenticated }
+ * @param {Object}  [options]
+ * @param {boolean} [options.orgOnly=false]      - Skip re-firing when the org hasn't changed
+ * @param {boolean} [options.authRequired=false] - Ensure auth before firing;
+ *   callback receives authenticated flag
+ */
+export function onConfigReady(callback, { orgOnly = false, authRequired = false } = {}) {
+  let lastOrg = null;
+  let lastAuthenticated = false;
+
+  const fire = async ({ org, site, force = false }) => {
+    if (orgOnly && org === lastOrg && lastAuthenticated && !force) return;
+    lastOrg = org;
+
+    let authenticated = true;
+    if (authRequired) {
+      authenticated = await ensureAuth(org, site);
+    }
+
+    // A newer fire() call may have changed the org while we awaited auth.
+    if (org !== lastOrg) return;
+
+    lastAuthenticated = authenticated;
+    callback({ org, site, authenticated });
+  };
+
+  const { org, site } = getCurrentConfig();
+  if (org) fire({ org, site });
+
+  window.addEventListener('config-update', (e) => fire(e.detail));
+}
+
+/**
+ * Returns a logging function that writes to the console block.
+ * Looks in the header first, then falls back to main.
+ * @returns {Function} (status, details) => void
+ */
+export function getConsoleLogger() {
+  return (status, details) => {
+    const block = document.querySelector('header .console')
+      || document.querySelector('main .console');
+    logResponse(block, status, details);
+  };
+}


### PR DESCRIPTION
## Summary

- `utils/admin-fetch.js` — factory that creates an admin API fetch function with optional response logging. Centralizes `ADMIN_API_BASE` and path-template substitution (`{org}`, `{site}`, etc.) so tools don't each hardcode them.
- `utils/tool-config.js` — shared utilities for tools that integrate with the header site-picker (coming in a follow-up PR):
  - `getCurrentConfig()` — reads `org`/`site` from URL search params
  - `onConfigReady(callback, { orgOnly, authRequired })` — fires when an org/site is selected, with optional dedup and auth gating
  - `getConsoleLogger()` — returns a logging function bound to the console block (header or main)

These are pure utilities with no UI impact. No existing code is changed.

## Test URLs

- Before/after: https://admin-nav-utils--helix-tools-website--adobe.aem.page/ (no visible change — utilities only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)