### PR TITLE
test: add unit tests for bulk and error-analyzer logic

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -1,4 +1,5 @@
 .*
+*.cjs
 *.md
 vendor/vendor.js
 vendor/.vendor-hash

--- a/.hlxignore
+++ b/.hlxignore
@@ -1,7 +1,6 @@
 .*
 *.md
-karma.config.js
-vendor/vendor.mjs
+vendor/vendor.js
 vendor/.vendor-hash
 LICENSE
 package.json

--- a/tools/bulk/scripts.js
+++ b/tools/bulk/scripts.js
@@ -1,4 +1,5 @@
 import { ensureLogin } from '../../blocks/profile/profile.js';
+import { analyzeUrls, extractOrgSite } from './utils.js';
 
 const log = document.getElementById('logger');
 const adminVersion = new URLSearchParams(window.location.search).get('hlx-admin-version');
@@ -19,12 +20,6 @@ function sleep(ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-}
-
-function extractOrgSite(url) {
-  const { hostname } = new URL(url);
-  const [, site, org] = hostname.split('.')[0].split('--');
-  return { org, site };
 }
 
 /**
@@ -186,119 +181,6 @@ const showSanitizationWarning = (changes) => {
 
     modal.showModal();
   });
-};
-
-/**
- * Analyze URLs for sanitization issues
- * @param {string[]} rawUrls - Array of raw URL strings
- * @returns {Object} Analysis results
- * @property {string[]} urls - Unique, sanitized URLs ready for processing
- * @property {string[]} urlsUnsanitized - Unique URLs in original form (one per urls entry)
- * @property {Array<{original: string, reason: string}>} rejected
- *   URLs that failed validation
- * @property {Array<{original: string, sanitized: string, changes: string[]}>} modified
- *   URLs that were sanitized
- * @property {string[]} deduplicated
- *   URLs that appeared multiple times (after sanitization)
- */
-const analyzeUrls = (rawUrls) => {
-  const rejected = [];
-  const modified = [];
-  const validUrls = [];
-  const sanitizedToOriginal = new Map();
-
-  const sanitizeUrl = (urlObj) => {
-    urlObj.hash = '';
-    urlObj.search = '';
-    const decodedPath = decodeURIComponent(urlObj.pathname);
-    urlObj.pathname = decodedPath
-      .toLowerCase()
-      .replace(/\/{2,}/g, '/')
-      .split('/')
-      .map((segment, i, arr) => {
-        const isLast = i === arr.length - 1;
-        const jsonSuffix = isLast && segment.endsWith('.json') ? '.json' : '';
-        const base = jsonSuffix ? segment.slice(0, -5) : segment;
-        return base
-          .normalize('NFD')
-          .replace(/[\u0300-\u036f]/g, '')
-          .replace(/[^a-z0-9_]+/g, '-')
-          .replace(/^-|-$/g, '') + jsonSuffix;
-      })
-      .join('/');
-    return urlObj.toString();
-  };
-
-  rawUrls.forEach((rawUrl) => {
-    if (!rawUrl) return;
-
-    try {
-      const urlObj = new URL(rawUrl.trim());
-      if (urlObj.protocol !== 'https:') {
-        rejected.push({
-          original: rawUrl,
-          reason: `Protocol '${urlObj.protocol}' not allowed (only https)`,
-        });
-        return;
-      }
-
-      const sanitized = sanitizeUrl(urlObj);
-
-      if (sanitized !== rawUrl) {
-        const changes = [];
-        try {
-          const original = new URL(rawUrl);
-          const result = new URL(sanitized);
-          if (original.hash && !result.hash) changes.push('hash removed');
-          if (original.search && !result.search) changes.push('query params removed');
-          if (original.pathname !== result.pathname) {
-            const decodedOriginalPath = decodeURIComponent(original.pathname);
-            const pathChanges = [];
-            if (decodedOriginalPath !== decodedOriginalPath.toLowerCase()) {
-              pathChanges.push('converted to lowercase');
-            }
-            if (/[^a-zA-Z0-9/_-]/.test(decodedOriginalPath)) {
-              pathChanges.push('special characters replaced');
-            }
-            if (/\/{2,}/.test(decodedOriginalPath)) {
-              pathChanges.push('duplicate slashes removed');
-            }
-            if (pathChanges.length > 0) {
-              changes.push(`path: ${pathChanges.join(', ')}`);
-            } else {
-              changes.push('path normalized');
-            }
-          }
-        } catch {
-          changes.push('normalized');
-        }
-        modified.push({ original: rawUrl, sanitized, changes });
-        validUrls.push(sanitized);
-      } else {
-        validUrls.push(sanitized);
-      }
-      if (!sanitizedToOriginal.has(sanitized)) {
-        sanitizedToOriginal.set(sanitized, rawUrl.trim());
-      }
-    } catch {
-      rejected.push({ original: rawUrl, reason: 'Invalid URL format' });
-    }
-  });
-
-  const urlCounts = new Map();
-  validUrls.forEach((url) => {
-    urlCounts.set(url, (urlCounts.get(url) || 0) + 1);
-  });
-
-  const urls = [...urlCounts.keys()];
-  const urlsUnsanitized = urls.map((url) => sanitizedToOriginal.get(url));
-  const deduplicated = Array.from(urlCounts.entries())
-    .filter(([, count]) => count > 1)
-    .map(([url]) => url);
-
-  return {
-    urls, urlsUnsanitized, rejected, modified, deduplicated,
-  };
 };
 
 document.getElementById('urls-form').addEventListener('submit', async (e) => {

--- a/tools/bulk/test/utils.test.js
+++ b/tools/bulk/test/utils.test.js
@@ -1,0 +1,123 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { analyzeUrls, extractOrgSite } from '../utils.js';
+
+describe('extractOrgSite', () => {
+  it('extracts org and site from a standard AEM URL', () => {
+    const result = extractOrgSite('https://main--mysite--myorg.aem.page/some/path');
+    assert.deepEqual(result, { org: 'myorg', site: 'mysite' });
+  });
+});
+
+describe('analyzeUrls', () => {
+  it('passes a clean HTTPS URL through unmodified', () => {
+    const result = analyzeUrls(['https://main--site--org.aem.page/some/path']);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/some/path']);
+    assert.deepEqual(result.rejected, []);
+    assert.deepEqual(result.modified, []);
+    assert.deepEqual(result.deduplicated, []);
+  });
+
+  it('rejects an HTTP URL', () => {
+    const result = analyzeUrls(['http://main--site--org.aem.page/page']);
+    assert.deepEqual(result.urls, []);
+    assert.equal(result.rejected.length, 1);
+    assert.equal(result.rejected[0].original, 'http://main--site--org.aem.page/page');
+    assert.match(result.rejected[0].reason, /https/);
+  });
+
+  it('rejects an invalid URL format', () => {
+    const result = analyzeUrls(['/just/a/path']);
+    assert.deepEqual(result.urls, []);
+    assert.equal(result.rejected.length, 1);
+    assert.equal(result.rejected[0].reason, 'Invalid URL format');
+  });
+
+  it('strips query params and records as modified', () => {
+    const result = analyzeUrls(['https://main--site--org.aem.page/path?foo=bar']);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/path']);
+    assert.equal(result.modified.length, 1);
+    assert.equal(result.modified[0].original, 'https://main--site--org.aem.page/path?foo=bar');
+    assert.ok(result.modified[0].changes.includes('query params removed'));
+  });
+
+  it('strips hash and records as modified', () => {
+    const result = analyzeUrls(['https://main--site--org.aem.page/path#section']);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/path']);
+    assert.equal(result.modified.length, 1);
+    assert.ok(result.modified[0].changes.includes('hash removed'));
+  });
+
+  it('lowercases uppercase path segments', () => {
+    const result = analyzeUrls(['https://main--site--org.aem.page/UPPER/Path']);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/upper/path']);
+    assert.equal(result.modified.length, 1);
+    assert.ok(result.modified[0].changes.some((c) => c.includes('lowercase')));
+  });
+
+  it('normalizes accented characters', () => {
+    const result = analyzeUrls(['https://main--site--org.aem.page/caf\u00e9']);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/cafe']);
+    assert.equal(result.modified.length, 1);
+  });
+
+  it('collapses duplicate slashes', () => {
+    const result = analyzeUrls(['https://main--site--org.aem.page//double//slash']);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/double/slash']);
+    assert.equal(result.modified.length, 1);
+    assert.ok(result.modified[0].changes.some((c) => c.includes('duplicate slashes')));
+  });
+
+  it('deduplicates identical URLs and reports them', () => {
+    const url = 'https://main--site--org.aem.page/page';
+    const result = analyzeUrls([url, url, url]);
+    assert.deepEqual(result.urls, [url]);
+    assert.deepEqual(result.deduplicated, [url]);
+  });
+
+  it('deduplicates URLs that normalize to the same value', () => {
+    const result = analyzeUrls([
+      'https://main--site--org.aem.page/Page',
+      'https://main--site--org.aem.page/page',
+    ]);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/page']);
+    assert.deepEqual(result.deduplicated, ['https://main--site--org.aem.page/page']);
+  });
+
+  it('preserves .json suffix on the last path segment', () => {
+    const result = analyzeUrls(['https://main--site--org.aem.page/data.json']);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/data.json']);
+    assert.deepEqual(result.modified, []);
+  });
+
+  it('silently skips null/empty entries', () => {
+    const result = analyzeUrls([null, '', 'https://main--site--org.aem.page/page']);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/page']);
+    assert.deepEqual(result.rejected, []);
+  });
+
+  it('rejects whitespace-only entries as invalid URL format', () => {
+    const result = analyzeUrls(['   ']);
+    assert.equal(result.rejected.length, 1);
+    assert.equal(result.rejected[0].reason, 'Invalid URL format');
+  });
+
+  it('tracks the original unsanitized URL alongside the sanitized one', () => {
+    const original = 'https://main--site--org.aem.page/UPPER';
+    const result = analyzeUrls([original]);
+    assert.deepEqual(result.urls, ['https://main--site--org.aem.page/upper']);
+    assert.deepEqual(result.urlsUnsanitized, [original]);
+  });
+
+  it('handles mixed valid, rejected, and modified URLs in one call', () => {
+    const result = analyzeUrls([
+      'https://main--site--org.aem.page/clean',
+      'http://main--site--org.aem.page/rejected',
+      'https://main--site--org.aem.page/Has Spaces',
+      'not-a-url',
+    ]);
+    assert.equal(result.urls.length, 2);
+    assert.equal(result.rejected.length, 2);
+    assert.equal(result.modified.length, 1);
+  });
+});

--- a/tools/bulk/utils.js
+++ b/tools/bulk/utils.js
@@ -1,0 +1,122 @@
+/**
+ * Extract org and site name from an AEM URL hostname.
+ * AEM URLs follow the pattern: branch--site--org.aem.page
+ * @param {string} url - Full URL (e.g. https://main--mysite--myorg.aem.page/path)
+ * @returns {{ org: string, site: string }}
+ */
+export function extractOrgSite(url) {
+  const { hostname } = new URL(url);
+  const [, site, org] = hostname.split('.')[0].split('--');
+  return { org, site };
+}
+
+/**
+ * Analyze URLs for sanitization issues.
+ * @param {string[]} rawUrls - Array of raw URL strings
+ * @returns {{
+ *   urls: string[],
+ *   urlsUnsanitized: string[],
+ *   rejected: Array<{original: string, reason: string}>,
+ *   modified: Array<{original: string, sanitized: string, changes: string[]}>,
+ *   deduplicated: string[]
+ * }}
+ */
+export const analyzeUrls = (rawUrls) => {
+  const rejected = [];
+  const modified = [];
+  const validUrls = [];
+  const sanitizedToOriginal = new Map();
+
+  const sanitizeUrl = (urlObj) => {
+    urlObj.hash = '';
+    urlObj.search = '';
+    const decodedPath = decodeURIComponent(urlObj.pathname);
+    urlObj.pathname = decodedPath
+      .toLowerCase()
+      .replace(/\/{2,}/g, '/')
+      .split('/')
+      .map((segment, i, arr) => {
+        const isLast = i === arr.length - 1;
+        const jsonSuffix = isLast && segment.endsWith('.json') ? '.json' : '';
+        const base = jsonSuffix ? segment.slice(0, -5) : segment;
+        return base
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, '')
+          .replace(/[^a-z0-9_]+/g, '-')
+          .replace(/^-|-$/g, '') + jsonSuffix;
+      })
+      .join('/');
+    return urlObj.toString();
+  };
+
+  rawUrls.forEach((rawUrl) => {
+    if (!rawUrl) return;
+
+    try {
+      const urlObj = new URL(rawUrl.trim());
+      if (urlObj.protocol !== 'https:') {
+        rejected.push({
+          original: rawUrl,
+          reason: `Protocol '${urlObj.protocol}' not allowed (only https)`,
+        });
+        return;
+      }
+
+      const sanitized = sanitizeUrl(urlObj);
+
+      if (sanitized !== rawUrl) {
+        const changes = [];
+        try {
+          const original = new URL(rawUrl);
+          const result = new URL(sanitized);
+          if (original.hash && !result.hash) changes.push('hash removed');
+          if (original.search && !result.search) changes.push('query params removed');
+          if (original.pathname !== result.pathname) {
+            const decodedOriginalPath = decodeURIComponent(original.pathname);
+            const pathChanges = [];
+            if (decodedOriginalPath !== decodedOriginalPath.toLowerCase()) {
+              pathChanges.push('converted to lowercase');
+            }
+            if (/[^a-zA-Z0-9/_-]/.test(decodedOriginalPath)) {
+              pathChanges.push('special characters replaced');
+            }
+            if (/\/{2,}/.test(decodedOriginalPath)) {
+              pathChanges.push('duplicate slashes removed');
+            }
+            if (pathChanges.length > 0) {
+              changes.push(`path: ${pathChanges.join(', ')}`);
+            } else {
+              changes.push('path normalized');
+            }
+          }
+        } catch {
+          changes.push('normalized');
+        }
+        modified.push({ original: rawUrl, sanitized, changes });
+        validUrls.push(sanitized);
+      } else {
+        validUrls.push(sanitized);
+      }
+      if (!sanitizedToOriginal.has(sanitized)) {
+        sanitizedToOriginal.set(sanitized, rawUrl.trim());
+      }
+    } catch {
+      rejected.push({ original: rawUrl, reason: 'Invalid URL format' });
+    }
+  });
+
+  const urlCounts = new Map();
+  validUrls.forEach((url) => {
+    urlCounts.set(url, (urlCounts.get(url) || 0) + 1);
+  });
+
+  const urls = [...urlCounts.keys()];
+  const urlsUnsanitized = urls.map((url) => sanitizedToOriginal.get(url));
+  const deduplicated = Array.from(urlCounts.entries())
+    .filter(([, count]) => count > 1)
+    .map(([url]) => url);
+
+  return {
+    urls, urlsUnsanitized, rejected, modified, deduplicated,
+  };
+};

--- a/tools/error-analyzer/test/utils.test.js
+++ b/tools/error-analyzer/test/utils.test.js
@@ -1,0 +1,89 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatNumber, formatRelativeDate } from '../utils.js';
+
+// Build a Date that is exactly `n` UTC days before today's UTC midnight.
+function daysAgo(n) {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() - n);
+  return d;
+}
+
+describe('formatNumber', () => {
+  it('returns numbers below 1000 as plain strings', () => {
+    assert.equal(formatNumber(0), '0');
+    assert.equal(formatNumber(1), '1');
+    assert.equal(formatNumber(999), '999');
+  });
+
+  it('formats thousands as K', () => {
+    assert.equal(formatNumber(1000), '1.0K');
+    assert.equal(formatNumber(1500), '1.5K');
+    assert.equal(formatNumber(999000), '999.0K');
+  });
+
+  it('formats millions as M', () => {
+    assert.equal(formatNumber(1000000), '1.0M');
+    assert.equal(formatNumber(2500000), '2.5M');
+  });
+
+  it('formats billions as B', () => {
+    assert.equal(formatNumber(1000000000), '1.0B');
+    assert.equal(formatNumber(3000000000), '3.0B');
+  });
+});
+
+describe('formatRelativeDate', () => {
+  it('returns "-" for an invalid date string', () => {
+    assert.equal(formatRelativeDate('not-a-date'), '-');
+    assert.equal(formatRelativeDate(''), '-');
+  });
+
+  it('returns "Today" for the current date', () => {
+    assert.equal(formatRelativeDate(new Date()), 'Today');
+  });
+
+  it('returns "Today" for a future date', () => {
+    assert.equal(formatRelativeDate(daysAgo(-1)), 'Today');
+  });
+
+  it('returns "Yesterday" for 1 day ago', () => {
+    assert.equal(formatRelativeDate(daysAgo(1)), 'Yesterday');
+  });
+
+  it('returns "X days ago" for 2–6 days ago', () => {
+    assert.equal(formatRelativeDate(daysAgo(2)), '2 days ago');
+    assert.equal(formatRelativeDate(daysAgo(6)), '6 days ago');
+  });
+
+  it('returns "Last week" for 7–13 days ago', () => {
+    assert.equal(formatRelativeDate(daysAgo(7)), 'Last week');
+    assert.equal(formatRelativeDate(daysAgo(13)), 'Last week');
+  });
+
+  it('returns "X weeks ago" for 14–29 days ago', () => {
+    assert.equal(formatRelativeDate(daysAgo(14)), '2 weeks ago');
+    assert.equal(formatRelativeDate(daysAgo(21)), '3 weeks ago');
+  });
+
+  it('returns "Last month" for 30–59 days ago', () => {
+    assert.equal(formatRelativeDate(daysAgo(30)), 'Last month');
+    assert.equal(formatRelativeDate(daysAgo(59)), 'Last month');
+  });
+
+  it('returns "X months ago" for 60–364 days ago', () => {
+    assert.equal(formatRelativeDate(daysAgo(60)), '2 months ago');
+    assert.equal(formatRelativeDate(daysAgo(90)), '3 months ago');
+  });
+
+  it('returns "Last year" for 365–729 days ago', () => {
+    assert.equal(formatRelativeDate(daysAgo(365)), 'Last year');
+    assert.equal(formatRelativeDate(daysAgo(729)), 'Last year');
+  });
+
+  it('returns "X years ago" for 730+ days ago', () => {
+    assert.equal(formatRelativeDate(daysAgo(730)), '2 years ago');
+    assert.equal(formatRelativeDate(daysAgo(1095)), '3 years ago');
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on top of #299 (`chore/fix-ci-testing`).

- Extracts `analyzeUrls` and `extractOrgSite` from `tools/bulk/scripts.js` into a new `tools/bulk/utils.js` so they can be imported in Node without triggering module-scope DOM access
- Adds 31 new tests across two tools:
  - `tools/bulk/utils.js`: `analyzeUrls` (HTTPS enforcement, query/hash stripping, lowercase, accent normalization, duplicate slashes, deduplication, `.json` suffix preservation, null/whitespace handling) and `extractOrgSite`
  - `tools/error-analyzer/utils.js`: `formatNumber` (K/M/B tiers) and `formatRelativeDate` (Today through years ago, boundary cases)
- All 47 tests pass (31 new + 16 existing optel tests)

## Test plan

- [ ] `npm test` passes locally (47/47)
- [ ] CI passes after merge of #299 base
- [ ] No behavior change to `tools/bulk/scripts.js` — functions moved, not modified

https://ci-tool-testing--helix-tools-website--adobe.aem.live/tools/error-analyzer/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)