### PR TITLE
remove min-width instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,8 +69,8 @@ The repository provides the basic structure, blocks, and configuration needed to
 - Follow Stylelint standard configuration
 - Use modern CSS features (CSS Grid, Flexbox, CSS Custom Properties)
 - Maintain responsive design principles
-  - Declare styles mobile first, use media queries at 600px/900px/1200px for tablet and desktop
-      - Declare styles mobile first, use `(width >= Npx)` range-notation media queries at 600px/900px/1200px for tablet and desktop
+  - Declare styles mobile first, use `(width >= Npx)` range-notation media queries at 600px/900px/1200px for tablet and desktop
+- Ensure all selectors are scoped to the block.
   - Bad: `.item-list`
   - Good: `.{blockname} .item-list`
 - Avoid classes `{blockname}-container` and `{blockname}-wrapper` as those are used on sections and could be confusing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ The repository provides the basic structure, blocks, and configuration needed to
 - Use modern CSS features (CSS Grid, Flexbox, CSS Custom Properties)
 - Maintain responsive design principles
   - Declare styles mobile first, use media queries at 600px/900px/1200px for tablet and desktop
-- Ensure all selectors are scoped to the block.
+      - Declare styles mobile first, use `(width >= Npx)` range-notation media queries at 600px/900px/1200px for tablet and desktop
   - Bad: `.item-list`
   - Good: `.{blockname} .item-list`
 - Avoid classes `{blockname}-container` and `{blockname}-wrapper` as those are used on sections and could be confusing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ The repository provides the basic structure, blocks, and configuration needed to
 - Follow Stylelint standard configuration
 - Use modern CSS features (CSS Grid, Flexbox, CSS Custom Properties)
 - Maintain responsive design principles
-  - Declare styles mobile first, use `min-width` media queries at 600px/900px/1200px for tablet and desktop
+  - Declare styles mobile first, use media queries at 600px/900px/1200px for tablet and desktop
 - Ensure all selectors are scoped to the block.
   - Bad: `.item-list`
   - Good: `.{blockname} .item-list`


### PR DESCRIPTION
Removed the skill instruction to use `min-width` because it did not pass the CSS linter during build.  The build required `width <= 900px` syntax to pass.

For an example, see https://github.com/adobe/helix-tools-website/actions/runs/24533778699/job/71723547324
```
Expected "context" media feature range notation  media-feature-range-notation
```

https://stylelint.io/user-guide/rules/media-feature-range-notation/#options

@shsteimer You may be able to recommend better verbiage than what is in my commit, but hopefully the point is clear.  If you feel that the skill is correct and the linting process is wrong, that may be another approach.