### PR TITLE
fix(availability): format Error objects in pop tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 **/lcov.info
 **/junit.xml
 
+.env
+
 helix-importer-ui
 .DS_Store
 *.bak

--- a/blocks/availability/availability.js
+++ b/blocks/availability/availability.js
@@ -59,17 +59,6 @@ function getHeader(headers, key) {
   return entry ? String(entry[1] ?? '') : '';
 }
 
-/**
- * Builds slim tooltip data from a pop response.
- * @param {object} popResponse
- * @param {boolean} headerMismatch
- * @returns {object|null}
- */
-/**
- * @param {object} popResponse
- * @param {string[]} [mismatchFields] - Field names that differ from live
- * @returns {object|null}
- */
 function formatError(err) {
   if (!err) return '';
   if (typeof err === 'string') return err;
@@ -87,6 +76,12 @@ function formatError(err) {
   return String(err);
 }
 
+/**
+ * Builds slim tooltip data from a pop response.
+ * @param {object} popResponse
+ * @param {string[]} [mismatchFields] - Field names that differ from live
+ * @returns {object|null}
+ */
 function buildPopTooltipData(popResponse, mismatchFields = []) {
   if (!popResponse) return null;
   const headers = popResponse.headers ?? popResponse.response?.headers ?? {};

--- a/blocks/availability/availability.js
+++ b/blocks/availability/availability.js
@@ -70,10 +70,27 @@ function getHeader(headers, key) {
  * @param {string[]} [mismatchFields] - Field names that differ from live
  * @returns {object|null}
  */
+function formatError(err) {
+  if (!err) return '';
+  if (typeof err === 'string') return err;
+  if (typeof err === 'object') {
+    const { name, message } = err;
+    if (name && message) return `${name}: ${message}`;
+    if (message) return String(message);
+    if (name) return String(name);
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
 function buildPopTooltipData(popResponse, mismatchFields = []) {
   if (!popResponse) return null;
   const headers = popResponse.headers ?? popResponse.response?.headers ?? {};
-  const popError = popResponse.error ?? '';
+  const popError = formatError(popResponse.error);
   const xError = getHeader(headers, 'x-error') || getHeader(headers, 'x_error') || '';
   const resp = popResponse.response ?? {};
   const message = resp.message ?? resp.Message ?? '';


### PR DESCRIPTION
## Summary
- Pop tooltips in the availability map showed `[object Object]` when the API returned an Error-like object (e.g. `TimeoutError`) for a POP.
- Added a `formatError` helper in `blocks/availability/availability.js` that renders such objects as `name: message` (or falls back sensibly) before the tooltip stringifies them.

## Preview
https://fix-availability-tooltip-error--helix-tools-website--adobe.aem.page/ops/cache/debugger.html

## Test plan
- [ ] Open the Cache Debugger preview, run a lookup, and hover a POP that errored with a TimeoutError — tooltip shows `TimeoutError: <message>` instead of `[object Object]`.
- [ ] Hover a POP with a string error — still renders as before.
- [ ] Hover a healthy POP — no `error:` line appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)