### PR TITLE
feat(optel): PNG export for Skyline chart in Explorer and Oversight

### DIFF
--- a/tools/optel/explorer/charts/skyline.js
+++ b/tools/optel/explorer/charts/skyline.js
@@ -727,4 +727,21 @@ export default class SkylineChart extends AbstractChart {
 
     this.chart.update();
   }
+
+  /**
+   * Download the current chart as a PNG (Chart.js canvas snapshot).
+   */
+  downloadPng() {
+    if (!this.chart || typeof this.chart.toBase64Image !== 'function') return;
+    const dataUrl = this.chart.toBase64Image('image/png', 1);
+    const domain = new URLSearchParams(window.location.search).get('domain') || 'chart';
+    const safe = domain.replace(/[^a-z0-9.-]/gi, '_').slice(0, 80);
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = `optel-skyline-${safe}.png`;
+    a.rel = 'noopener';
+    document.body.append(a);
+    a.click();
+    a.remove();
+  }
 }

--- a/tools/optel/explorer/explorer.html
+++ b/tools/optel/explorer/explorer.html
@@ -109,6 +109,31 @@
             </div>
             <figure>
               <div class="chart-container solitary">
+                <button
+                  type="button"
+                  id="chart-download-png"
+                  class="chart-download"
+                  aria-label="Download skyline chart as PNG"
+                  title="Download PNG"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                </button>
                 <canvas id="time-series"></canvas>
               </div>
               <div class="filter-tags"></div>

--- a/tools/optel/explorer/rum-slicer.css
+++ b/tools/optel/explorer/rum-slicer.css
@@ -224,6 +224,32 @@ figure .chart-container {
   height: calc(100vh - 450px);
 }
 
+.optel-explorer .chart-download {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: var(--border-m, 1px) solid var(--color-border, #c6c6c6);
+  border-radius: var(--rounding-s, 4px);
+  background: light-dark(var(--gray-25, #fff), var(--gray-800, #292929));
+  color: light-dark(var(--gray-800, #292929), var(--gray-25, #f3f3f3));
+  cursor: pointer;
+  opacity: 0.9;
+}
+
+.optel-explorer .chart-download:hover,
+.optel-explorer .chart-download:focus-visible {
+  opacity: 1;
+  outline: var(--border-m, 1px) solid var(--color-link, #5050b8);
+  outline-offset: 2px;
+}
+
 figure .chart-container.sankey {
   height: calc(100vh - 300px);
 }

--- a/tools/optel/explorer/slicer.js
+++ b/tools/optel/explorer/slicer.js
@@ -330,6 +330,12 @@ function init() {
 
   elems.viewSelect = document.getElementById('view');
   elems.canvas = document.getElementById('time-series');
+  const chartDownloadPng = document.getElementById('chart-download-png');
+  if (chartDownloadPng) {
+    chartDownloadPng.addEventListener('click', () => {
+      herochart.downloadPng();
+    });
+  }
   elems.timezoneElement = document.getElementById('timezone');
   elems.lowDataWarning = document.getElementById('low-data-warning');
   elems.incognito = document.querySelector('incognito-checkbox');

--- a/tools/optel/oversight/charts/skyline.js
+++ b/tools/optel/oversight/charts/skyline.js
@@ -898,4 +898,21 @@ export default class SkylineChart extends AbstractChart {
 
     this.chart.update();
   }
+
+  /**
+   * Download the current chart as a PNG (Chart.js canvas snapshot).
+   */
+  downloadPng() {
+    if (!this.chart || typeof this.chart.toBase64Image !== 'function') return;
+    const dataUrl = this.chart.toBase64Image('image/png', 1);
+    const domain = new URLSearchParams(window.location.search).get('domain') || 'chart';
+    const safe = domain.replace(/[^a-z0-9.-]/gi, '_').slice(0, 80);
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = `optel-oversight-skyline-${safe}.png`;
+    a.rel = 'noopener';
+    document.body.append(a);
+    a.click();
+    a.remove();
+  }
 }

--- a/tools/optel/oversight/explorer.html
+++ b/tools/optel/oversight/explorer.html
@@ -112,6 +112,31 @@
 
           <figure>
             <div class="chart-container solitary">
+              <button
+                type="button"
+                id="chart-download-png"
+                class="chart-download"
+                aria-label="Download skyline chart as PNG"
+                title="Download PNG"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" y1="15" x2="12" y2="3" />
+                </svg>
+              </button>
               <canvas id="time-series"></canvas>
             </div>
             <div class="filter-tags"></div>

--- a/tools/optel/oversight/rum-slicer.css
+++ b/tools/optel/oversight/rum-slicer.css
@@ -355,6 +355,32 @@ figure .chart-container {
   height: calc(100vh - 400px);
 }
 
+.optel-oversight .chart-download {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: var(--border-m, 1px) solid var(--color-border, #c6c6c6);
+  border-radius: var(--rounding-s, 4px);
+  background: light-dark(var(--gray-25, #fff), var(--gray-800, #292929));
+  color: light-dark(var(--gray-800, #292929), var(--gray-25, #f3f3f3));
+  cursor: pointer;
+  opacity: 0.9;
+}
+
+.optel-oversight .chart-download:hover,
+.optel-oversight .chart-download:focus-visible {
+  opacity: 1;
+  outline: var(--border-m, 1px) solid var(--color-link, #5050b8);
+  outline-offset: 2px;
+}
+
 figure .chart-container.sankey {
   height: calc(100vh - 300px);
 }

--- a/tools/optel/oversight/single.html
+++ b/tools/optel/oversight/single.html
@@ -123,6 +123,31 @@
 
           <figure>
             <div class="chart-container solitary">
+              <button
+                type="button"
+                id="chart-download-png"
+                class="chart-download"
+                aria-label="Download skyline chart as PNG"
+                title="Download PNG"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" y1="15" x2="12" y2="3" />
+                </svg>
+              </button>
               <canvas id="time-series"></canvas>
             </div>
             <div class="filter-tags"></div>

--- a/tools/optel/oversight/slicer.js
+++ b/tools/optel/oversight/slicer.js
@@ -497,6 +497,12 @@ function init() {
 
   elems.viewSelect = document.getElementById('view');
   elems.canvas = document.getElementById('time-series');
+  const chartDownloadPng = document.getElementById('chart-download-png');
+  if (chartDownloadPng && typeof herochart.downloadPng === 'function') {
+    chartDownloadPng.addEventListener('click', () => {
+      herochart.downloadPng();
+    });
+  }
   elems.timezoneElement = document.getElementById('timezone');
   elems.lowDataWarning = document.getElementById('low-data-warning');
   elems.incognito = document.querySelector('incognito-checkbox');


### PR DESCRIPTION
- Add corner download control (icon button) on chart; Chart.js toBase64Image
- Explorer: optel-skyline-<domain>.png; wire slicer to SkylineChart.downloadPng
- Oversight: same UI on explorer and single; optel-oversight-skyline-<domain>.png
- Oversight slicer only binds when downloadPng exists (other views use other charts)

Made-with: Cursor

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/optel/explorer/explorer.html?domain=emigrationbrewing.com&view=month&domainkey=open
- After: https://skyline-png--helix-tools-website--adobe.aem.live/tools/optel/explorer/explorer.html?domain=emigrationbrewing.com&view=month&domainkey=open
