### PR TITLE
fix: iterate on User Admin UX for adding one user vs multiple users quickly

### DIFF
--- a/tools/user-admin/index.html
+++ b/tools/user-admin/index.html
@@ -10,6 +10,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>User Admin</title>
+  <link rel="preload" href="/styles/styles.css" as="style" />
+  <link rel="preload" href="/utils/config/config.css" as="style" />
+  <link rel="preload" href="/utils/card-ui/card-ui.css" as="style" />
+  <link rel="preload" href="/tools/user-admin/user-admin.css" as="style" />
   <script nonce="aem" src="/scripts/aem.js" type="module"></script>
   <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/utils/config/config.css" />

--- a/tools/user-admin/index.html
+++ b/tools/user-admin/index.html
@@ -10,10 +10,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>User Admin</title>
-  <link rel="preload" href="/styles/styles.css" as="style" />
-  <link rel="preload" href="/utils/config/config.css" as="style" />
-  <link rel="preload" href="/utils/card-ui/card-ui.css" as="style" />
-  <link rel="preload" href="/tools/user-admin/user-admin.css" as="style" />
   <script nonce="aem" src="/scripts/aem.js" type="module"></script>
   <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/utils/config/config.css" />

--- a/tools/user-admin/user-admin.css
+++ b/tools/user-admin/user-admin.css
@@ -219,6 +219,7 @@ dialog.user-admin-modal .modal-error {
 dialog.user-admin-modal .modal-footer {
   display: flex;
   gap: var(--spacing-s);
+  align-items: center;
   justify-content: flex-end;
   padding: var(--spacing-l);
   border-top: 1px solid var(--color-border);
@@ -226,6 +227,32 @@ dialog.user-admin-modal .modal-footer {
 
 dialog.user-admin-modal .modal-footer .delete-btn {
   margin-right: auto;
+}
+
+dialog.user-admin-modal .modal-footer .footer-roles-reference {
+  margin-right: auto;
+  position: relative;
+}
+
+dialog.user-admin-modal .modal-footer .footer-roles-reference .roles-reference-panel {
+  position: absolute;
+  bottom: calc(100% + var(--spacing-s));
+  left: 0;
+  min-width: 320px;
+  max-width: 480px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: var(--spacing-m);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: var(--shadow-hover);
+  z-index: 1;
+}
+
+dialog.user-admin-modal .modal-footer .footer-roles-reference .roles-reference-link {
+  display: block;
+  margin-top: var(--spacing-s);
 }
 
 dialog.user-admin-modal .form-field {
@@ -442,82 +469,6 @@ dialog.user-admin-modal .user-entry-remove:hover {
 
 dialog.user-admin-modal .user-entry:only-child .user-entry-remove {
   display: none;
-}
-
-/* Modal toolbar - pinned strip between header and scrollable body */
-dialog.user-admin-modal .modal-toolbar {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-s);
-  padding: var(--spacing-m) var(--spacing-l);
-  background: light-dark(var(--gray-50), var(--gray-800));
-  border-bottom: 1px solid var(--color-border);
-  flex-shrink: 0;
-}
-
-dialog.user-admin-modal .modal-toolbar .presets-label {
-  font-weight: 600;
-  font-size: var(--body-size-m);
-  color: var(--color-text);
-  margin: 0;
-}
-
-dialog.user-admin-modal .modal-toolbar .presets-btn-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-xs);
-}
-
-dialog.user-admin-modal .presets-collapse {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-s);
-}
-
-dialog.user-admin-modal .presets-collapse summary.presets-label {
-  cursor: pointer;
-  list-style: none;
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-}
-
-dialog.user-admin-modal .presets-collapse summary.presets-label::-webkit-details-marker {
-  display: none;
-}
-
-dialog.user-admin-modal .presets-collapse summary.presets-label::before {
-  content: '\25B6';
-  font-size: 0.55em;
-  color: var(--color-font-grey);
-  transition: transform 0.2s ease;
-}
-
-dialog.user-admin-modal .presets-collapse[open] summary.presets-label::before {
-  transform: rotate(90deg);
-}
-
-dialog.user-admin-modal .role-preset-btn {
-  background: none;
-  border: 1px dashed var(--color-border);
-  border-radius: 20px;
-  padding: 4px 12px;
-  font-size: var(--body-size-s);
-  cursor: pointer;
-  color: var(--color-font-grey);
-  transition: border-color 0.15s ease, color 0.15s ease, background-color 0.15s ease;
-}
-
-dialog.user-admin-modal .role-preset-btn:hover {
-  border-color: var(--blue-500);
-  border-style: solid;
-  color: var(--blue-700);
-}
-
-dialog.user-admin-modal .role-preset-btn.active {
-  background: var(--blue-100);
-  border: 1px solid var(--blue-500);
-  color: var(--blue-700);
 }
 
 /* Compact role pills */

--- a/tools/user-admin/user-admin.css
+++ b/tools/user-admin/user-admin.css
@@ -56,6 +56,12 @@
     "badges"
     "actions";
   gap: var(--spacing-s);
+  cursor: pointer;
+}
+
+.user-admin .user-card:focus-visible {
+  outline: 2px solid var(--blue-500);
+  outline-offset: 2px;
 }
 
 .user-admin .user-card .user-card-info {
@@ -106,6 +112,27 @@
 .user-admin .user-card .card-item-actions {
   grid-area: actions;
   margin-top: var(--spacing-s);
+}
+
+.user-admin .user-card .user-card-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--body-size-xs);
+  color: var(--color-font-grey);
+  font-style: italic;
+  pointer-events: none;
+  transition: color 0.15s ease;
+}
+
+.user-admin .user-card:hover .user-card-hint,
+.user-admin .user-card:focus-visible .user-card-hint {
+  color: var(--blue-700);
+}
+
+.user-admin .user-card .user-card-hint svg {
+  width: 12px;
+  height: 12px;
 }
 
 /* List view specific styles */

--- a/tools/user-admin/user-admin.css
+++ b/tools/user-admin/user-admin.css
@@ -443,14 +443,9 @@ dialog.user-admin-modal .user-entry.has-error {
 
 dialog.user-admin-modal .user-entry-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   margin-bottom: var(--spacing-s);
-}
-
-dialog.user-admin-modal .user-entry-label {
-  font-weight: 600;
-  font-size: var(--body-size-m);
 }
 
 dialog.user-admin-modal .user-entry-remove {

--- a/tools/user-admin/user-admin.css
+++ b/tools/user-admin/user-admin.css
@@ -59,11 +59,6 @@
   cursor: pointer;
 }
 
-.user-admin .user-card:focus-visible {
-  outline: 2px solid var(--blue-500);
-  outline-offset: 2px;
-}
-
 .user-admin .user-card .user-card-info {
   grid-area: info;
   display: flex;
@@ -112,27 +107,6 @@
 .user-admin .user-card .card-item-actions {
   grid-area: actions;
   margin-top: var(--spacing-s);
-}
-
-.user-admin .user-card .user-card-hint {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--body-size-xs);
-  color: var(--color-font-grey);
-  font-style: italic;
-  pointer-events: none;
-  transition: color 0.15s ease;
-}
-
-.user-admin .user-card:hover .user-card-hint,
-.user-admin .user-card:focus-visible .user-card-hint {
-  color: var(--blue-700);
-}
-
-.user-admin .user-card .user-card-hint svg {
-  width: 12px;
-  height: 12px;
 }
 
 /* List view specific styles */
@@ -396,13 +370,13 @@ dialog.user-admin-modal .roles-reference summary::-webkit-details-marker {
 }
 
 dialog.user-admin-modal .roles-reference summary::before {
-  content: '\25B6';
+  content: '\25BC';
   font-size: 0.55em;
   transition: transform 0.2s ease;
 }
 
 dialog.user-admin-modal .roles-reference[open] summary::before {
-  transform: rotate(90deg);
+  transform: rotate(180deg);
 }
 
 dialog.user-admin-modal .roles-reference-list {

--- a/tools/user-admin/user-admin.css
+++ b/tools/user-admin/user-admin.css
@@ -468,6 +468,35 @@ dialog.user-admin-modal .modal-toolbar .presets-btn-row {
   gap: var(--spacing-xs);
 }
 
+dialog.user-admin-modal .presets-collapse {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+}
+
+dialog.user-admin-modal .presets-collapse summary.presets-label {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+dialog.user-admin-modal .presets-collapse summary.presets-label::-webkit-details-marker {
+  display: none;
+}
+
+dialog.user-admin-modal .presets-collapse summary.presets-label::before {
+  content: '\25B6';
+  font-size: 0.55em;
+  color: var(--color-font-grey);
+  transition: transform 0.2s ease;
+}
+
+dialog.user-admin-modal .presets-collapse[open] summary.presets-label::before {
+  transform: rotate(90deg);
+}
+
 dialog.user-admin-modal .role-preset-btn {
   background: none;
   border: 1px dashed var(--color-border);

--- a/tools/user-admin/user-admin.css
+++ b/tools/user-admin/user-admin.css
@@ -277,11 +277,6 @@ dialog.user-admin-modal .modal-footer .footer-roles-reference .roles-reference-p
   z-index: 1;
 }
 
-dialog.user-admin-modal .modal-footer .footer-roles-reference .roles-reference-link {
-  display: block;
-  margin-top: var(--spacing-s);
-}
-
 dialog.user-admin-modal .form-field {
   margin-bottom: var(--spacing-l);
 }
@@ -437,6 +432,11 @@ dialog.user-admin-modal .roles-reference-link {
   padding-top: var(--spacing-xs);
   font-size: var(--body-size-s);
   color: var(--blue-600);
+}
+
+dialog.user-admin-modal .modal-footer .footer-roles-reference .roles-reference-link {
+  display: block;
+  margin-top: var(--spacing-s);
 }
 
 /* Danger Button - scoped to user-admin-modal */

--- a/tools/user-admin/user-admin.js
+++ b/tools/user-admin/user-admin.js
@@ -233,7 +233,7 @@ function createRolesReference() {
   const details = document.createElement('details');
   details.className = 'roles-reference';
   const summary = document.createElement('summary');
-  summary.textContent = 'What do these roles mean?';
+  summary.textContent = 'What do the Roles mean?';
   details.appendChild(summary);
   const panel = document.createElement('div');
   panel.className = 'roles-reference-panel';

--- a/tools/user-admin/user-admin.js
+++ b/tools/user-admin/user-admin.js
@@ -681,9 +681,6 @@ function createUserCard(user) {
   const card = document.createElement('div');
   card.className = 'card-item user-card';
   card.dataset.email = user.email.toLowerCase();
-  card.setAttribute('role', 'button');
-  card.setAttribute('tabindex', '0');
-  card.setAttribute('aria-label', `Edit user ${user.email}`);
 
   // Build card structure safely to prevent XSS
   const infoDiv = document.createElement('div');
@@ -710,15 +707,6 @@ function createUserCard(user) {
     badgesDiv.appendChild(badge);
   });
 
-  const hintDiv = document.createElement('div');
-  hintDiv.className = 'card-item-actions user-card-hint';
-  hintDiv.setAttribute('aria-hidden', 'true');
-  hintDiv.innerHTML = `${icon('edit')} <span>Click to edit</span>`;
-
-  card.appendChild(infoDiv);
-  card.appendChild(badgesDiv);
-  card.appendChild(hintDiv);
-
   const openEdit = () => {
     openEditUserModal(user, async (updatedUser) => {
       if (accessConfig.type === 'site') {
@@ -728,13 +716,28 @@ function createUserCard(user) {
     });
   };
 
-  card.addEventListener('click', openEdit);
-  card.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      openEdit();
-    }
+  const actionsDiv = document.createElement('div');
+  actionsDiv.className = 'card-item-actions';
+  const editBtn = document.createElement('button');
+  editBtn.type = 'button';
+  editBtn.className = 'card-item-btn edit-btn';
+  editBtn.innerHTML = `${icon('edit')} Edit`;
+  editBtn.addEventListener('click', (e) => {
+    // prevent the card-level click handler from firing a second time
+    e.stopPropagation();
+    openEdit();
   });
+  actionsDiv.appendChild(editBtn);
+
+  // make the entire card a click target as a UX convenience; the button
+  // above remains the semantic/a11y entry point for keyboard and AT users.
+  // dialog backdrop clicks won't reach the card because the open <dialog>
+  // is modal and catches those clicks itself.
+  card.addEventListener('click', openEdit);
+
+  card.appendChild(infoDiv);
+  card.appendChild(badgesDiv);
+  card.appendChild(actionsDiv);
 
   return card;
 }

--- a/tools/user-admin/user-admin.js
+++ b/tools/user-admin/user-admin.js
@@ -458,10 +458,12 @@ function openAddUsersModal(onSave) {
 
   const presetsDiv = document.createElement('div');
   presetsDiv.className = 'modal-toolbar';
-  const presetsLabel = document.createElement('span');
+  const presetsCollapse = document.createElement('details');
+  presetsCollapse.className = 'presets-collapse';
+  const presetsLabel = document.createElement('summary');
   presetsLabel.className = 'presets-label';
   presetsLabel.textContent = 'Roles (Apply to all)';
-  presetsDiv.appendChild(presetsLabel);
+  presetsCollapse.appendChild(presetsLabel);
   const presetsBtnRow = document.createElement('div');
   presetsBtnRow.className = 'presets-btn-row';
   const syncPresets = () => {
@@ -490,7 +492,8 @@ function openAddUsersModal(onSave) {
     });
     presetsBtnRow.appendChild(btn);
   });
-  presetsDiv.appendChild(presetsBtnRow);
+  presetsCollapse.appendChild(presetsBtnRow);
+  presetsDiv.appendChild(presetsCollapse);
   presetsDiv.appendChild(createRolesReference());
 
   entriesContainer.addEventListener('change', syncPresets);
@@ -499,7 +502,7 @@ function openAddUsersModal(onSave) {
 
   const {
     dialog, content, bodyDiv, saveBtn, closeModal, setConfirmClose,
-  } = createModal('Add Users', 'Add 2 Users');
+  } = createModal('Add Users', 'Add 1 User');
 
   dialog.addEventListener('close', () => presetsObserver.disconnect());
 
@@ -531,10 +534,10 @@ function openAddUsersModal(onSave) {
   };
 
   const firstEntry = createUserEntry(entriesContainer, updateSaveLabel);
-  createUserEntry(entriesContainer, updateSaveLabel);
   firstEntry.querySelector('input[type="email"]').focus();
 
   addAnotherBtn.addEventListener('click', () => {
+    presetsCollapse.open = true;
     const entry = createUserEntry(entriesContainer, updateSaveLabel);
     entry.querySelector('input[type="email"]').focus();
     entry.scrollIntoView({ behavior: 'smooth', block: 'nearest' });

--- a/tools/user-admin/user-admin.js
+++ b/tools/user-admin/user-admin.js
@@ -269,15 +269,10 @@ function createUserEntry(entriesContainer, updateSaveLabel, selectedRoles = []) 
 
   const header = document.createElement('div');
   header.className = 'user-entry-header';
-  const label = document.createElement('span');
-  label.className = 'user-entry-label';
-  const num = entriesContainer.querySelectorAll('.user-entry').length + 1;
-  label.textContent = `User ${num}`;
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
   removeBtn.className = 'user-entry-remove';
   removeBtn.textContent = 'Remove';
-  header.appendChild(label);
   header.appendChild(removeBtn);
 
   const emailField = document.createElement('div');
@@ -309,15 +304,8 @@ function createUserEntry(entriesContainer, updateSaveLabel, selectedRoles = []) 
   entry.appendChild(emailField);
   entry.appendChild(rolesField);
 
-  const renumber = () => {
-    entriesContainer.querySelectorAll('.user-entry').forEach((e, i) => {
-      e.querySelector('.user-entry-label').textContent = `User ${i + 1}`;
-    });
-  };
-
   removeBtn.addEventListener('click', () => {
     entry.remove();
-    renumber();
     updateSaveLabel();
   });
 
@@ -576,9 +564,6 @@ function openAddUsersModal(onSave) {
       const added = err.addedCount || 0;
       if (added > 0) {
         validEntries.slice(0, added).forEach((entry) => entry.remove());
-        entriesContainer.querySelectorAll('.user-entry').forEach((el, i) => {
-          el.querySelector('.user-entry-label').textContent = `User ${i + 1}`;
-        });
         const failed = users.length - added;
         showModalError(dialog, `${added} user(s) added, ${failed} failed: ${err.message}`);
       } else {

--- a/tools/user-admin/user-admin.js
+++ b/tools/user-admin/user-admin.js
@@ -235,6 +235,8 @@ function createRolesReference() {
   const summary = document.createElement('summary');
   summary.textContent = 'What do these roles mean?';
   details.appendChild(summary);
+  const panel = document.createElement('div');
+  panel.className = 'roles-reference-panel';
   const list = document.createElement('dl');
   list.className = 'roles-reference-list';
   ROLES.forEach((role) => {
@@ -251,14 +253,15 @@ function createRolesReference() {
   link.target = '_blank';
   link.className = 'roles-reference-link';
   link.textContent = 'Learn more about roles';
-  details.appendChild(list);
-  details.appendChild(link);
+  panel.appendChild(list);
+  panel.appendChild(link);
+  details.appendChild(panel);
   return details;
 }
 
 let entryIdCounter = 0;
 
-function createUserEntry(entriesContainer, updateSaveLabel) {
+function createUserEntry(entriesContainer, updateSaveLabel, selectedRoles = []) {
   entryIdCounter += 1;
   const entryId = entryIdCounter;
   const entry = document.createElement('div');
@@ -296,7 +299,7 @@ function createUserEntry(entriesContainer, updateSaveLabel) {
   const rolesLabel = document.createElement('label');
   rolesLabel.id = rolesFieldId;
   rolesLabel.textContent = 'Roles';
-  const rolesContainer = createCompactRoleCheckboxes();
+  const rolesContainer = createCompactRoleCheckboxes(selectedRoles);
   rolesContainer.setAttribute('role', 'group');
   rolesContainer.setAttribute('aria-labelledby', rolesFieldId);
   rolesField.appendChild(rolesLabel);
@@ -456,57 +459,13 @@ function openAddUsersModal(onSave) {
   const entriesContainer = document.createElement('div');
   entriesContainer.className = 'user-entries';
 
-  const presetsDiv = document.createElement('div');
-  presetsDiv.className = 'modal-toolbar';
-  const presetsCollapse = document.createElement('details');
-  presetsCollapse.className = 'presets-collapse';
-  const presetsLabel = document.createElement('summary');
-  presetsLabel.className = 'presets-label';
-  presetsLabel.textContent = 'Roles (Apply to all)';
-  presetsCollapse.appendChild(presetsLabel);
-  const presetsBtnRow = document.createElement('div');
-  presetsBtnRow.className = 'presets-btn-row';
-  const syncPresets = () => {
-    presetsBtnRow.querySelectorAll('.role-preset-btn').forEach((btn) => {
-      const { role } = btn.dataset;
-      const cbs = entriesContainer.querySelectorAll(`input[type="checkbox"][value="${role}"]`);
-      const allChecked = cbs.length > 0 && [...cbs].every((cb) => cb.checked);
-      btn.classList.toggle('active', allChecked);
-    });
-  };
-
-  ROLES.forEach((role) => {
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'role-preset-btn';
-    btn.dataset.role = role;
-    btn.textContent = ROLE_DESCRIPTIONS[role].label;
-    btn.addEventListener('click', () => {
-      const cbs = entriesContainer.querySelectorAll(`input[type="checkbox"][value="${role}"]`);
-      const allChecked = cbs.length > 0 && [...cbs].every((cb) => cb.checked);
-      cbs.forEach((cb) => { cb.checked = !allChecked; });
-      entriesContainer.querySelectorAll('.user-entry.has-error').forEach((entry) => {
-        entry.classList.remove('has-error');
-      });
-      syncPresets();
-    });
-    presetsBtnRow.appendChild(btn);
-  });
-  presetsCollapse.appendChild(presetsBtnRow);
-  presetsDiv.appendChild(presetsCollapse);
-  presetsDiv.appendChild(createRolesReference());
-
-  entriesContainer.addEventListener('change', syncPresets);
-  const presetsObserver = new MutationObserver(syncPresets);
-  presetsObserver.observe(entriesContainer, { childList: true });
-
   const {
-    dialog, content, bodyDiv, saveBtn, closeModal, setConfirmClose,
+    dialog, bodyDiv, footerDiv, saveBtn, closeModal, setConfirmClose,
   } = createModal('Add Users', 'Add 1 User');
 
-  dialog.addEventListener('close', () => presetsObserver.disconnect());
-
-  content.insertBefore(presetsDiv, bodyDiv);
+  const rolesReference = createRolesReference();
+  rolesReference.classList.add('footer-roles-reference');
+  footerDiv.prepend(rolesReference);
 
   setConfirmClose(async () => {
     const emails = dialog.querySelectorAll('input[type="email"]');
@@ -537,8 +496,12 @@ function openAddUsersModal(onSave) {
   firstEntry.querySelector('input[type="email"]').focus();
 
   addAnotherBtn.addEventListener('click', () => {
-    presetsCollapse.open = true;
-    const entry = createUserEntry(entriesContainer, updateSaveLabel);
+    const previousEntries = entriesContainer.querySelectorAll('.user-entry');
+    const previousEntry = previousEntries[previousEntries.length - 1];
+    const previousRoles = previousEntry
+      ? [...previousEntry.querySelectorAll('input[type="checkbox"]:checked')].map((cb) => cb.value)
+      : [];
+    const entry = createUserEntry(entriesContainer, updateSaveLabel, previousRoles);
     entry.querySelector('input[type="email"]').focus();
     entry.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   });

--- a/tools/user-admin/user-admin.js
+++ b/tools/user-admin/user-admin.js
@@ -681,6 +681,9 @@ function createUserCard(user) {
   const card = document.createElement('div');
   card.className = 'card-item user-card';
   card.dataset.email = user.email.toLowerCase();
+  card.setAttribute('role', 'button');
+  card.setAttribute('tabindex', '0');
+  card.setAttribute('aria-label', `Edit user ${user.email}`);
 
   // Build card structure safely to prevent XSS
   const infoDiv = document.createElement('div');
@@ -707,27 +710,31 @@ function createUserCard(user) {
     badgesDiv.appendChild(badge);
   });
 
-  const actionsDiv = document.createElement('div');
-  actionsDiv.className = 'card-item-actions';
-  const editBtn = document.createElement('button');
-  editBtn.type = 'button';
-  editBtn.className = 'card-item-btn edit-btn';
-  editBtn.innerHTML = `${icon('edit')} Edit`;
+  const hintDiv = document.createElement('div');
+  hintDiv.className = 'card-item-actions user-card-hint';
+  hintDiv.setAttribute('aria-hidden', 'true');
+  hintDiv.innerHTML = `${icon('edit')} <span>Click to edit</span>`;
 
-  editBtn.addEventListener('click', () => {
+  card.appendChild(infoDiv);
+  card.appendChild(badgesDiv);
+  card.appendChild(hintDiv);
+
+  const openEdit = () => {
     openEditUserModal(user, async (updatedUser) => {
       if (accessConfig.type === 'site') {
         return updateSiteUserRoles(updatedUser);
       }
       return updateOrgUserRoles(updatedUser);
     });
+  };
+
+  card.addEventListener('click', openEdit);
+  card.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      openEdit();
+    }
   });
-
-  actionsDiv.appendChild(editBtn);
-
-  card.appendChild(infoDiv);
-  card.appendChild(badgesDiv);
-  card.appendChild(actionsDiv);
 
   return card;
 }


### PR DESCRIPTION
* Default to 1 user when user clicks on "Add User(s)"
* Collapse "Role (Apply to All)" by default - only expand it when user clicks "Add Another User"
* Other iterations to simplify Add new user dialog
* Making the whole row clickable for existing users

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/user-admin/index.html
- After: https://user-admin-iterate--helix-tools-website--adobe.aem.live/tools/user-admin/index.html
