### PR TITLE
chore(helix-admin): trim verbose comments from PR #312

### DIFF
--- a/blocks/profile/profile.js
+++ b/blocks/profile/profile.js
@@ -147,8 +147,7 @@ function createLoginButton(org, loginInfo, closeModal) {
     loginUrl.searchParams.append('extensionId', getSidekickId());
     const loginWindow = window.open(loginUrl.toString(), '_blank');
 
-    // give up tracking the login window after 60 seconds; signal cancellation
-    // so listeners (e.g. executeAdminRequest) can stop awaiting login.
+    // 60s safety net: fire `profile-cancelled` if the login window is left open.
     let giveUpTimer;
 
     // wait for login window to be closed, then dispatch event
@@ -162,8 +161,8 @@ function createLoginButton(org, loginInfo, closeModal) {
           const orgTitle = loginButton.parentElement.parentElement;
           loginButton.replaceWith(createLoginButton(org, newLoginInfo));
           fetchUserInfo(orgTitle.querySelector('.user-info'), org, selectedSite, newLoginInfo);
-          // dispatch profile-update before closing so listeners observe the
-          // login outcome before the dialog's close handler fires profile-cancelled
+          // fire profile-update before close so listeners see the outcome
+          // before the close handler fires profile-cancelled.
           dispatchProfileEvent('update', newLoginInfo);
           if (closeModal) {
             document.querySelector('#profile-modal').close();
@@ -405,14 +404,12 @@ async function showModal(block, focusedOrg) {
     dialog.classList.add('profile-modal');
     dialog.id = 'profile-modal';
     dialog.closedBy = 'any';
-    // Bind once: the dialog is reused across showModal calls, so attaching
-    // here avoids stacking duplicate listeners that would each emit
-    // `profile-cancelled` on every close.
+    // Bind once — the dialog is reused; rebinding stacks duplicate emissions.
     dialog.addEventListener('close', () => {
       dialog.classList.remove('edit-mode');
-      // Always fires on close, including after a successful login. Listeners
-      // that care about the login outcome should observe `profile-update`
-      // (dispatched first) and remove themselves before this fires.
+      // Fires on every close, including post-login. Listeners that care about
+      // the login outcome should observe `profile-update` (dispatched first)
+      // and remove themselves before this fires.
       dispatchProfileEvent('cancelled');
     });
     block.append(dialog);

--- a/scripts/helix-admin.js
+++ b/scripts/helix-admin.js
@@ -3,47 +3,29 @@ const ADMIN_BASE = 'https://admin.hlx.page';
 /**
  * Normalized response envelope returned by every admin API call.
  *
- * Methods do not throw on non-2xx — `ok`/`status` carry the outcome and
- * `error` carries the `x-error` response header. `text()` and `json()` are
- * thin pass-throughs to the underlying Response, which is single-use; call
- * one of them, not both, and only once.
- *
- * Tools can reference this typedef from other modules:
- *   import('./helix-admin.js').AdminResponse
+ * Non-2xx is carried via `ok`/`status`/`error`, never thrown. `text()` and
+ * `json()` wrap the underlying Response body, which is single-use — call
+ * one, not both, and only once.
  *
  * @typedef {object} AdminResponse
- * @property {boolean} ok                              `resp.ok`
- * @property {number} status                           HTTP status code
- * @property {() => Promise<string>} text              read response body as text
- * @property {() => Promise<any>} json                 read response body as JSON
- * @property {string} error                            `x-error` response header, '' if absent
- * @property {{method: string, url: string}} request   method+url echo for logging
+ * @property {boolean} ok
+ * @property {number} status
+ * @property {() => Promise<string>} text
+ * @property {() => Promise<any>} json
+ * @property {string} error                            `x-error` header, '' if absent
+ * @property {{method: string, url: string}} request   echo for logging
  */
 
 /**
- * Build an admin client with optional request-init defaults applied to every
- * call. The default export is built with no defaults — equivalent to plain
- * `fetch(url, {method, body, headers})`. Use `admin.withRequestInit(...)` to
- * derive a client with overridden defaults (e.g. `{credentials: 'include'}`
- * for cookie-bearing cross-origin calls, or `{cache: 'no-cache'}` to bypass
- * the HTTP cache on polling endpoints).
+ * Build an admin client. The default export has no init defaults; use
+ * `admin.withRequestInit(...)` to derive one with e.g. `credentials: 'include'`
+ * or `cache: 'no-cache'`.
  *
  * @param {RequestInit} [defaults] merged into every request's init
  */
 function createAdmin(defaults = {}) {
-  /**
-   * Issue an admin API request and return a normalized envelope.
-   *
-   * Resource methods on the returned `admin` object are thin wrappers around
-   * this; tools shouldn't call it directly.
-   *
-   * @param {object} args
-   * @param {string} args.method            HTTP method
-   * @param {string} args.url               fully-qualified admin API URL
-   * @param {string|FormData} [args.body]   request body, omit for GET
-   * @param {string} [args.contentType]     value for the content-type header
-   * @returns {Promise<AdminResponse>}
-   */
+  // Tools shouldn't call this directly — use the resource methods on the
+  // returned `admin` object.
   async function request({
     method, url, body, contentType,
   }) {
@@ -71,22 +53,16 @@ function createAdmin(defaults = {}) {
   }
 
   /**
-   * Bind a config-API context to a site (or just an org).
-   *
-   * The returned object exposes `url` (the URL prefix of this context) and
-   * resource methods. Site-scoped resources are only present when `site` is
-   * provided — calling them on an org-only context yields a TypeError at the
-   * call site, which is the intended failure mode.
-   *
-   * Each resource method is a callable that also exposes `.url` (the canonical
-   * URL of that resource) for test assertions and debugging.
+   * Bind a config-API context to an org (and optionally a site). The returned
+   * object exposes `url` and resource methods; each resource method also has
+   * a `.url` for test assertions. Site-scoped resources are absent on an
+   * org-only context — calling them throws a TypeError, by design.
    *
    * @param {{org: string, site?: string}} coords
    */
   function config({ org, site }) {
     const orgUrl = `${ADMIN_BASE}/config/${org}`;
 
-    // Org-scoped context — site-only resources are deliberately absent.
     if (!site) {
       return { url: orgUrl };
     }
@@ -95,11 +71,6 @@ function createAdmin(defaults = {}) {
 
     const robotsUrl = `${siteUrl}/robots.txt`;
     /**
-     * Get or replace the site's robots.txt.
-     *
-     * Also exposes a `.url` property (the canonical URL of this resource) for
-     * test assertions and debugging.
-     *
      * @param {string} [body] omit to GET; pass text to POST as `text/plain`
      * @returns {Promise<AdminResponse>}
      */
@@ -119,15 +90,10 @@ function createAdmin(defaults = {}) {
   }
 
   /**
-   * Derive an admin client whose request init defaults are merged with `extra`
-   * (later wins). Use for tools whose calls need non-default fetch options:
+   * Derive a client whose init defaults are merged with `extra` (later wins).
+   * The original client is unaffected; chainable.
    *
-   *   const admin2 = admin.withRequestInit({ credentials: 'include' });
-   *   await admin2.config({ org, site }).robots();
-   *
-   * Calls made through the original `admin` are unaffected. Compose by chaining.
-   *
-   * @param {RequestInit} extra  init fields to merge over current defaults
+   * @param {RequestInit} extra
    */
   function withRequestInit(extra) {
     return createAdmin({ ...defaults, ...extra });

--- a/utils/admin-request.js
+++ b/utils/admin-request.js
@@ -2,19 +2,7 @@ import { ensureLogin } from '../blocks/profile/profile.js';
 import { updateConfig } from './config/config.js';
 
 /**
- * Auth-handling policies for {@link executeAdminRequest}.
- *
- * - `none` — call the request fn; no auth handling.
- * - `retryOn401` — call the request fn; on 401, prompt login and retry once.
- * - `preflightAndRetry` — prompt login first, then call the request fn,
- *   and retry once on 401.
- *
- * In `retryOn401` and `preflightAndRetry`, when the user is not signed in,
- * `ensureLogin` opens the profile modal and the helper awaits the outcome:
- * a `profile-update` event with the org in its detail (login completed) or
- * a `profile-cancelled` event (modal closed, login window closed without
- * completion, or profile.js's 60s give-up timer). The request fn is only
- * re-invoked if login succeeded.
+ * Auth-handling policy for {@link executeAdminRequest}.
  *
  * @readonly
  * @enum {string}
@@ -25,16 +13,6 @@ export const AuthMode = Object.freeze({
   PREFLIGHT_AND_RETRY: 'preflightAndRetry',
 });
 
-/**
- * @typedef {import('../scripts/helix-admin.js').AdminResponse} AdminResponse
- */
-
-/**
- * Race the next `profile-update` and `profile-cancelled`. Resolves true
- * only if `profile-update` fires with `org` in its detail. The give-up
- * timer (60s after a login window is opened) lives in profile.js, which
- * fires `profile-cancelled` when it expires.
- */
 function waitForLogin(org) {
   return new Promise((resolve) => {
     const handlers = {};
@@ -52,26 +30,18 @@ function waitForLogin(org) {
 
 /**
  * Execute an admin API request with optional auth pre-check and 401 retry.
+ * Returns `null` if the user fails to complete login.
  *
- * The request fn is the unit of retry — it must be safe to invoke up to twice.
- *
- * Returns `null` when auth handling is enabled and the user does not
- * complete login (cancels the modal, closes the login window, or
- * profile.js's give-up timer fires).
- *
- * On any 2xx result, calls `updateConfig()` to persist the org/site combo
- * to URL params and localStorage. Non-2xx results don't trigger persistence
- * — a 4xx/5xx may not actually validate the org/site (404 could mean the
- * org doesn't exist, 403 could mean wrong permissions on a wrong combo).
- * `updateConfig` is a no-op on pages without the org/site fields, so
- * callers don't need to opt in.
+ * `updateConfig()` only fires on 2xx — a 4xx/5xx may not actually validate
+ * the org/site combo (e.g. 404 could mean the org doesn't exist). It's a
+ * no-op on pages without the org/site fields, so callers needn't opt in.
  *
  * @template {{ status: number }} T
- * @param {() => Promise<T>} requestFn         returns an AdminResponse-like envelope (`{ status }`)
- * @param {object} authConfig                  auth context for the request
- * @param {string} authConfig.org              org for `ensureLogin`
- * @param {string} [authConfig.site]           site for `ensureLogin`
- * @param {AuthMode} [authConfig.policy]       auth handling mode (default: `retryOn401`)
+ * @param {() => Promise<T>} requestFn       must be safe to invoke twice
+ * @param {object} authConfig
+ * @param {string} authConfig.org
+ * @param {string} [authConfig.site]
+ * @param {AuthMode} [authConfig.policy]     default: `retryOn401`
  * @returns {Promise<T | null>}
  */
 export async function executeAdminRequest(requestFn, authConfig) {


### PR DESCRIPTION
## Summary
- Strip overly verbose JSDoc and comments added in #312 down to the load-bearing "why" content
- Net: 67 lines of comments removed across three files (38 insertions / 105 deletions)
- **No code changes** — comments/JSDoc only

### Files
- `scripts/helix-admin.js`: collapse `AdminResponse`, `createAdmin`, `request`, `config`, `robots`, and `withRequestInit` JSDoc. Keep the Headers-normalization comment and the org-only TypeError note (both load-bearing "why").
- `utils/admin-request.js`: compress `AuthMode` / `executeAdminRequest` JSDoc; drop unused `AdminResponse` typedef alias; remove `waitForLogin` JSDoc.
- `blocks/profile/profile.js`: trim the four comment blocks introduced in #312 (give-up timer, profile-update ordering, bind-once, close contract). Pre-existing comments untouched.

## Preview
Comment-only change — no user-visible behavior to demonstrate. Smoke-test the consumer that exercises the touched code:
- https://chore-trim-helix-admin-comments--helix-tools-website--adobe.aem.page/tools/robots-edit/index.html

## Test plan
- [x] `npm run lint` clean (pre-existing unrelated `no-console` warnings only)
- [x] `npm test` green (215 tests, 100% coverage on `admin-request.js`)
- [ ] Manual: load robots-edit, verify fetch + save still trigger login modal and persist org/site

🤖 Generated with [Claude Code](https://claude.com/claude-code)