### PR TITLE
fix: ensure vendoring updates for renovate. fail ci build in case of …

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,11 @@
 name: Build
-on: [push]
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -11,5 +17,14 @@ jobs:
       with:
         node-version: 24
     - run: npm ci
+    - name: Verify repo matches install output (e.g. vendor/ after lockfile changes)
+      run: |
+        if [ -z "$(git status --porcelain)" ]; then
+          exit 0
+        fi
+        echo "::error::Working tree is dirty after \`npm ci\` (postinstall runs vendoring). Commit the diff — usually \`vendor/\` and \`.vendor-hash\` when \`package-lock.json\` changed."
+        git status
+        git diff --stat HEAD
+        exit 1
     - run: npm run lint
     - run: npm test

--- a/.github/workflows/vendor-sync.yml
+++ b/.github/workflows/vendor-sync.yml
@@ -1,0 +1,46 @@
+# Keep vendor/ in sync for Mend-hosted Renovate PRs only. The hosted app does not
+# run npm scripts during lockfile updates and only allows a fixed postUpgradeTasks
+# allowlist, so Renovate cannot run `npm run vendor` itself. Other PRs must update
+# vendor/ manually. Fork PRs are skipped (same-repo + renovate[bot] author only).
+name: Vendor sync
+
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+
+concurrency:
+  group: vendor-sync-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: npm run vendor
+      - name: Commit and push vendor
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet HEAD -- vendor/; then
+            echo "Vendor already matches lockfile."
+            exit 0
+          fi
+          git add vendor/
+          git commit -m "chore: sync vendor bundles after lockfile change"
+          git push origin HEAD:"${HEAD_REF}"

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -24,10 +24,5 @@
       "allowedVersions": "^8.0.0",
       "description": "Pin ESLint to v8 until airbnb-base supports v9+"
     }
-  ],
-  "postUpgradeTasks": {
-    "commands": ["npm run vendor"],
-    "fileFilters": ["vendor/**"],
-    "executionMode": "branch"
-  }
+  ]
 }

--- a/vendor/vendor.js
+++ b/vendor/vendor.js
@@ -3,9 +3,13 @@
  * Bundles vendor dependencies into single-file browser ESM modules.
  *
  * Run via `npm run vendor` after updating dependencies.
- * Also runs automatically via postinstall and Renovate postUpgradeTasks.
+ * Also runs automatically via postinstall. Renovate bot PRs are updated by
+ * `.github/workflows/vendor-sync.yml` because Mend-hosted Renovate
+ * cannot run custom post-upgrade commands or npm lifecycle scripts.
  *
- * Idempotent: skips rebuild when package-lock.json is unchanged.
+ * Idempotent locally: skips rebuild when package-lock.json is unchanged and
+ * `.vendor-hash` matches. In CI (`CI` env, e.g. GitHub Actions) always rebuilds
+ * so vendored files cannot quietly drift from hand edits without a lockfile change.
  *
  * To add a dependency:
  *   1. Add it to `dependencies` in package.json and run `npm install`
@@ -55,7 +59,7 @@ const [lockfile, storedHash] = await Promise.all([
 
 const currentHash = createHash('sha256').update(lockfile).digest('hex');
 
-if (currentHash === storedHash) {
+if (currentHash === storedHash && !process.env.CI) {
   console.log('vendor: up to date');
   process.exit(0);
 }


### PR DESCRIPTION
…vendoring updates

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/
- After: https://<branch>--helix-tools-website--adobe.aem.live/
