### PR TITLE
chore: exclude optel explorer from recent tools

### DIFF
--- a/blocks/recent-tools/recent-tools.js
+++ b/blocks/recent-tools/recent-tools.js
@@ -1,5 +1,11 @@
+const EXCLUDE_TOOLS = ['/tools/optel/explorer/', '/tools/optel/oversight/'];
+
 function dedupKey(path) {
   return path.replace(/\/index\.html$/, '/').replace(/^(\/tools\/[^/]+)\.html$/, '$1/');
+}
+
+function isExcluded(path) {
+  return EXCLUDE_TOOLS.some((prefix) => path.startsWith(prefix));
 }
 
 function labelFromPath(path) {
@@ -49,6 +55,7 @@ export default async function decorate(block) {
     return { path, ts: Date.now() };
   });
   const merged = [...visits, ...links]
+    .filter((item) => !isExcluded(item.path))
     .map((item) => ({ ...item, key: dedupKey(item.path) }))
     .filter((item, i, arr) => arr.findIndex((v) => v.key === item.key) === i)
     .slice(0, 5);

--- a/blocks/recent-tools/recent-tools.js
+++ b/blocks/recent-tools/recent-tools.js
@@ -1,4 +1,4 @@
-const EXCLUDE_TOOLS = ['/tools/optel/explorer/', '/tools/optel/oversight/'];
+const EXCLUDE_TOOLS = ['/tools/optel/'];
 
 function dedupKey(path) {
   return path.replace(/\/index\.html$/, '/').replace(/^(\/tools\/[^/]+)\.html$/, '$1/');


### PR DESCRIPTION
If you use the optel explorer, it shows up in recent-tools as `Optel — Oversight — Explorer` and it probably shouldn't, as clicking it just takes you to a blank dashboard.

<img width="823" height="47" alt="image" src="https://github.com/user-attachments/assets/6a309cd7-9a63-4463-933a-0492b5737bb1" />
