### PR TITLE
fix(code-review): remove plugin, fix cleanup, batch inline suggestions

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -39,13 +39,7 @@ Use to review an existing pull request.
 
 **Invoke:** `/code-review <PR-number>` or automatically via GitHub Actions
 
-**Process:**
-```bash
-gh pr view <PR-number> --json title,body,headRefName,files
-gh pr diff <PR-number>
-```
-
-**Output:** Create GitHub suggestions for one-click fixes (see below).
+See **Output Format → PR Review Mode** below for the full process.
 
 ---
 
@@ -114,15 +108,16 @@ Report findings directly:
 
 ### PR Review Mode
 
-Complete your full analysis before making any API calls.
+Complete phases in order. **No write API calls until Phase 2.**
 
-**Gather information:**
+**Phase 1: Gather information**
 ```bash
-gh pr view <PR-number> --json title,body,headRefName,files
+gh pr view <PR-number> --json title,body,headRefName,files,headRefOid
 gh pr diff <PR-number>
 ```
+Read changed files for context. Complete your full analysis before proceeding.
 
-**Clean up previous bot comments:**
+**Phase 2: Clean up previous bot comments**
 ```bash
 for id in $(gh api repos/{owner}/{repo}/pulls/<PR-number>/comments --jq '[.[] | select(.user.login == "github-actions[bot]") | .id] | .[]'); do
   gh api -X DELETE repos/{owner}/{repo}/pulls/comments/$id
@@ -132,7 +127,14 @@ for id in $(gh api repos/{owner}/{repo}/issues/<PR-number>/comments --jq '[.[] |
 done
 ```
 
-**Post all inline suggestions in a single call** (skip if none). Only suggest when the issue is in the current diff and you are confident the fix is correct — otherwise put it in the summary.
+**Phase 3: Post inline suggestions (single API call — skip entirely if none)**
+
+Only suggest when ALL of these are true:
+- Issue exists in the current HEAD diff (don't flag already-fixed code)
+- Fix is within diff lines, not surrounding context
+- You are confident the replacement is correct
+
+When in doubt, put it in the Phase 4 summary instead.
 
 `position` = 1-based line number counting from the `@@` header line in the unified diff.
 
@@ -144,7 +146,7 @@ gh api --method POST repos/{owner}/{repo}/pulls/<PR-number>/reviews \
   --field 'comments=[{"path":"FILE","position":N,"body":"**Fix:** REASON\n\n```suggestion\nCODE\n```"}]'
 ```
 
-**Post summary comment:**
+**Phase 4: Post summary comment**
 ```bash
 gh pr comment <PR-number> --body "<!-- claude-code-review -->
 ## Code Review

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -114,45 +114,43 @@ Report findings directly:
 
 ### PR Review Mode
 
-**For every fixable issue, create a GitHub suggestion** for one-click acceptance:
+Complete your full analysis before making any API calls.
+
+**Gather information:**
+```bash
+gh pr view <PR-number> --json title,body,headRefName,files
+gh pr diff <PR-number>
+```
+
+**Clean up previous bot comments:**
+```bash
+for id in $(gh api repos/{owner}/{repo}/pulls/<PR-number>/comments --jq '[.[] | select(.user.login == "github-actions[bot]") | .id] | .[]'); do
+  gh api -X DELETE repos/{owner}/{repo}/pulls/comments/$id
+done
+for id in $(gh api repos/{owner}/{repo}/issues/<PR-number>/comments --jq '[.[] | select(.body | contains("<!-- claude-code-review -->")) | .id] | .[]'); do
+  gh api -X DELETE repos/{owner}/{repo}/issues/comments/$id
+done
+```
+
+**Post all inline suggestions in a single call** (skip if none). Only suggest when the issue is in the current diff and you are confident the fix is correct — otherwise put it in the summary.
+
+`position` = 1-based line number counting from the `@@` header line in the unified diff.
 
 ```bash
-# Get commit SHA
 COMMIT_SHA=$(gh api repos/{owner}/{repo}/pulls/<PR-number> --jq '.head.sha')
-
-# Post review with suggestions
 gh api --method POST repos/{owner}/{repo}/pulls/<PR-number>/reviews \
-  --input /tmp/review.json
+  --field commit_id="$COMMIT_SHA" \
+  --field event="COMMENT" \
+  --field 'comments=[{"path":"FILE","position":N,"body":"**Fix:** REASON\n\n```suggestion\nCODE\n```"}]'
 ```
 
-**Review JSON format:**
-
-```json
-{
-  "commit_id": "<commit-sha>",
-  "event": "COMMENT",
-  "comments": [
-    {
-      "path": "path/to/file.js",
-      "position": 12,
-      "body": "**Fix:** Remove debug statement\n\n```suggestion\n// fixed code here\n```"
-    }
-  ]
-}
-```
-
-**IMPORTANT:** `position` is the line number in the diff output, NOT the file. Count from the start of the diff including headers.
-
-**Then post a summary comment:**
-
+**Post summary comment:**
 ```bash
-gh pr comment <PR-number> --body "## Code Review
+gh pr comment <PR-number> --body "<!-- claude-code-review -->
+## Code Review
 
 ### Issues Found
-- [List by severity]
-
-### One-Click Fixes
-GitHub Suggestions added. Go to **Files changed** → **Commit suggestion**.
+- [List by severity: BLOCKING / SHOULD FIX / CONSIDER]
 
 ### Verdict
 [APPROVE / REQUEST CHANGES / COMMENT]"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,62 +20,74 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Glob" "Grep" "LS" "Skill"'
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
+          claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Glob" "Grep" "LS"'
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
-            ## Your Task
+            ## Phase 1: Read and analyze (no write API calls in this phase)
 
-            1. **Run the code-review plugin** for general review:
-               ```
-               /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-               ```
+            Gather information:
+            ```bash
+            gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body,headRefName,files,headRefOid
+            gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
+            ```
 
-            2. **Read the local skill** at `.claude/skills/code-review/SKILL.md` for EDS-specific criteria and review against those as well.
+            Read `.claude/skills/code-review/SKILL.md` for EDS-specific review criteria.
+            Read `.claude/skills/code-review/resources/review-checklist.md` for detailed checks.
+            Read any changed files you need for context.
 
-            3. **For EVERY fixable issue, create a GitHub suggestion** using the Pull Request Reviews API:
-               ```bash
-               # Get the commit SHA first
-               COMMIT_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.head.sha')
+            Complete your full analysis before proceeding. Do not make any write API calls in this phase.
 
-               # Create review with suggestions (position = line in diff, NOT file)
-               gh api --method POST repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
-                 --field commit_id="$COMMIT_SHA" \
-                 --field event="COMMENT" \
-                 --field 'comments=[{"path":"file.js","position":10,"body":"**Fix:** Description\n\n```suggestion\nfixed code\n```"}]'
-               ```
+            ## Phase 2: Clean up previous bot comments
 
-               This creates one-click "Commit suggestion" buttons in the PR Files tab.
+            Delete inline review comments from previous runs:
+            ```bash
+            for id in $(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.user.login == "github-actions[bot]") | .id] | .[]'); do
+              gh api -X DELETE repos/${{ github.repository }}/pulls/comments/$id
+            done
+            ```
 
-            4. **Delete any existing Claude review comments** before posting a new summary:
-               ```bash
-               # Find and delete previous review comments
-               for id in $(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.body | contains("<!-- claude-code-review -->")) | .id'); do
-                 gh api -X DELETE repos/${{ github.repository }}/issues/comments/$id
-               done
-               ```
+            Delete previous summary comments:
+            ```bash
+            for id in $(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.body | contains("<!-- claude-code-review -->")) | .id] | .[]'); do
+              gh api -X DELETE repos/${{ github.repository }}/issues/comments/$id
+            done
+            ```
 
-            5. **Post a summary comment** (with marker for future cleanup):
-               ```bash
-               gh pr comment ${{ github.event.pull_request.number }} --body "<!-- claude-code-review -->
-               ## Code Review Summary
+            ## Phase 3: Post inline suggestions (at most one API call — skip entirely if none)
 
-               ### Issues Found
-               - List issues by severity (BLOCKING / SHOULD FIX / CONSIDER)
+            Only include a suggestion when ALL of these are true:
+            - The issue exists in the current HEAD diff (do not flag already-fixed code)
+            - You are confident the suggested replacement is correct
+            - The fix is within lines that appear in the diff (not surrounding context)
 
-               ### One-Click Fixes
-               I've added GitHub Suggestions for fixable issues. Go to **Files changed** and click **Commit suggestion** to apply.
+            When in doubt, report the issue in the Phase 4 summary instead.
 
-               ### Verdict
-               APPROVE / REQUEST CHANGES / COMMENT"
-               ```
+            `position` is the 1-based line number counting from the `@@` header line in the unified diff output.
 
-            IMPORTANT: Always use GitHub suggestions (```suggestion blocks) so authors can fix issues with one click.
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+            Post all suggestions in a single call:
+            ```bash
+            COMMIT_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.head.sha')
+            gh api --method POST repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+              --field commit_id="$COMMIT_SHA" \
+              --field event="COMMENT" \
+              --field 'comments=[{"path":"FILE","position":N,"body":"**Fix:** REASON\n\n```suggestion\nCODE\n```"}]'
+            ```
+
+            Skip this step entirely if there are no suggestions.
+
+            ## Phase 4: Post summary comment
+
+            ```bash
+            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "<!-- claude-code-review -->
+            ## Code Review
+
+            ### Findings
+            [List issues grouped by BLOCKING / SHOULD FIX / CONSIDER. Write \"No issues found.\" if clean.]
+
+            ### Verdict
+            [APPROVE / REQUEST CHANGES / COMMENT]"
+            ```

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,67 +27,12 @@ jobs:
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
-            ## Phase 1: Read and analyze (no write API calls in this phase)
-
-            Gather information:
-            ```bash
-            gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json title,body,headRefName,files,headRefOid
-            gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }}
-            ```
-
-            Read `.claude/skills/code-review/SKILL.md` for EDS-specific review criteria.
+            Read `.claude/skills/code-review/SKILL.md` and follow the **PR Review Mode** process.
             Read `.claude/skills/code-review/resources/review-checklist.md` for detailed checks.
             Read any changed files you need for context.
 
-            Complete your full analysis before proceeding. Do not make any write API calls in this phase.
+            Substitute placeholders in all commands:
+            - `{owner}/{repo}` → `${{ github.repository }}`
+            - `<PR-number>` → `${{ github.event.pull_request.number }}`
 
-            ## Phase 2: Clean up previous bot comments
-
-            Delete inline review comments from previous runs:
-            ```bash
-            for id in $(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.user.login == "github-actions[bot]") | .id] | .[]'); do
-              gh api -X DELETE repos/${{ github.repository }}/pulls/comments/$id
-            done
-            ```
-
-            Delete previous summary comments:
-            ```bash
-            for id in $(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '[.[] | select(.body | contains("<!-- claude-code-review -->")) | .id] | .[]'); do
-              gh api -X DELETE repos/${{ github.repository }}/issues/comments/$id
-            done
-            ```
-
-            ## Phase 3: Post inline suggestions (at most one API call — skip entirely if none)
-
-            Only include a suggestion when ALL of these are true:
-            - The issue exists in the current HEAD diff (do not flag already-fixed code)
-            - You are confident the suggested replacement is correct
-            - The fix is within lines that appear in the diff (not surrounding context)
-
-            When in doubt, report the issue in the Phase 4 summary instead.
-
-            `position` is the 1-based line number counting from the `@@` header line in the unified diff output.
-
-            Post all suggestions in a single call:
-            ```bash
-            COMMIT_SHA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.head.sha')
-            gh api --method POST repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
-              --field commit_id="$COMMIT_SHA" \
-              --field event="COMMENT" \
-              --field 'comments=[{"path":"FILE","position":N,"body":"**Fix:** REASON\n\n```suggestion\nCODE\n```"}]'
-            ```
-
-            Skip this step entirely if there are no suggestions.
-
-            ## Phase 4: Post summary comment
-
-            ```bash
-            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "<!-- claude-code-review -->
-            ## Code Review
-
-            ### Findings
-            [List issues grouped by BLOCKING / SHOULD FIX / CONSIDER. Write \"No issues found.\" if clean.]
-
-            ### Verdict
-            [APPROVE / REQUEST CHANGES / COMMENT]"
-            ```
+            When running `gh pr view` and `gh pr diff`, add `--repo ${{ github.repository }}`.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,16 +23,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Glob" "Grep" "LS"'
+          claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Glob" "Grep" "LS" "Skill"'
           prompt: |
-            Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
-
-            Read `.claude/skills/code-review/SKILL.md` and follow the **PR Review Mode** process.
-            Read `.claude/skills/code-review/resources/review-checklist.md` for detailed checks.
-            Read any changed files you need for context.
-
-            Substitute placeholders in all commands:
-            - `{owner}/{repo}` → `${{ github.repository }}`
-            - `<PR-number>` → `${{ github.event.pull_request.number }}`
+            Use the Skill tool to invoke the `code-review` skill for PR #${{ github.event.pull_request.number }}.
 
             When running `gh pr view` and `gh pr diff`, add `--repo ${{ github.repository }}`.
+            Substitute `{owner}/{repo}` with `${{ github.repository }}` in all commands.


### PR DESCRIPTION
## Summary

- Removes the `code-review@claude-code-plugins` marketplace plugin — its inline comment tool (`mcp__github_inline_comment__create_inline_comment`) is only available in the managed Claude Code Review service, not in `claude-code-action@v1`, so it contributed nothing in this context and was the source of leaked \"test\"/\"test1\" debug comments
- Fixes comment cleanup to cover **both** inline review comments (`/pulls/{pr}/comments`) and issue summary comments (`/issues/{pr}/comments`) — the old cleanup only hit the latter, leaving old inline suggestions permanently stacked across pushes
- Restructures the prompt into explicit phases: read-only analysis first, then cleanup, then a **single batched** `gh api` call for all suggestions — eliminates the fragmented multi-review-object posting that caused duplicate inline comments
- Uses local `SKILL.md` exclusively for EDS-specific review criteria (block scoping, aem.js, preview URLs, etc.)

## Test URLs

This PR is itself the test bed — the automated review should run on it and demonstrate the fixed behavior.

- Before: https://main--helix-tools-website--adobe.aem.page/
- After: https://fix/claude-code-review--helix-tools-website--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)