### PR TITLE
fix(widget): use console.error for error logging

### DIFF
--- a/blocks/widget/widget.js
+++ b/blocks/widget/widget.js
@@ -27,7 +27,7 @@ export default async function decorate(widget) {
           }
         } catch (error) {
           // eslint-disable-next-line no-console
-          console.log(`failed to load module for ${widgetName}`, error);
+          console.error(`failed to load module for ${widgetName}`, error);
         }
         resolve();
       })();
@@ -35,7 +35,7 @@ export default async function decorate(widget) {
     await Promise.all([cssLoaded, decorationComplete]);
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.log(`failed to load block ${widgetName}`, error);
+    console.error(`failed to load block ${widgetName}`, error);
   }
   widget.className = `widget ${widgetName}`;
   widget.dataset.widgetUrl = widgetUrl;


### PR DESCRIPTION
## Summary

- `console.log` for caught errors in `blocks/widget/widget.js` replaced with `console.error` so errors surface correctly in browser devtools

## Test URLs

- Before: https://main--helix-tools-website--adobe.aem.page/
- After: https://test-code-review-trigger--helix-tools-website--adobe.aem.page/

> This PR exists to test the automated code review workflow — watching for clean output (no duplicate comments, no "test" fragments, proper cleanup on re-push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)