### PR TITLE
fix(code-review): target claude[bot] in comment cleanup

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -119,10 +119,10 @@ Read changed files for context. Complete your full analysis before proceeding.
 
 **Phase 2: Clean up previous bot comments**
 ```bash
-for id in $(gh api repos/{owner}/{repo}/pulls/<PR-number>/comments --jq '[.[] | select(.user.login == "github-actions[bot]") | .id] | .[]'); do
+for id in $(gh api repos/{owner}/{repo}/pulls/<PR-number>/comments --jq '[.[] | select(.user.login == "claude[bot]") | .id] | .[]'); do
   gh api -X DELETE repos/{owner}/{repo}/pulls/comments/$id
 done
-for id in $(gh api repos/{owner}/{repo}/issues/<PR-number>/comments --jq '[.[] | select(.body | contains("<!-- claude-code-review -->")) | .id] | .[]'); do
+for id in $(gh api repos/{owner}/{repo}/issues/<PR-number>/comments --jq '[.[] | select(.user.login == "claude[bot]") | .id] | .[]'); do
   gh api -X DELETE repos/{owner}/{repo}/issues/comments/$id
 done
 ```


### PR DESCRIPTION
## Summary

- The cleanup phase filtered for `github-actions[bot]` but the action posts via `CLAUDE_CODE_OAUTH_TOKEN`, so all comments appear as `claude[bot]` — the filter never matched anything
- Stale inline suggestions and summary comments stacked up across PR pushes with no cleanup
- Switches both filters to `select(.user.login == "claude[bot]")`

## Test plan

- [ ] Merge and push a commit to an open PR — old `claude[bot]` comments should be deleted before the new review is posted

https://fix/code-review-cleanup-filter--helix-tools-website--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)