### PR TITLE
fix(code-review): add concurrency group and allow Write tool

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,6 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: true
           claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Write" "Glob" "Grep" "LS" "Skill"'
           prompt: |
             Use the Skill tool to invoke the `code-review` skill for PR #${{ github.event.pull_request.number }}.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest
@@ -23,7 +27,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Glob" "Grep" "LS" "Skill"'
+          claude_args: '--allowedTools "Bash(gh *)" "Bash(git *)" "Read" "Write" "Glob" "Grep" "LS" "Skill"'
           prompt: |
             Use the Skill tool to invoke the `code-review` skill for PR #${{ github.event.pull_request.number }}.
 


### PR DESCRIPTION
## Summary

- **Duplicate comments**: adds a `concurrency` group scoped to the PR number with `cancel-in-progress: true` — back-to-back pushes cancel the previous run instead of letting two reviews post simultaneously
- **No inline suggestions**: `Write` was missing from `allowedTools`; CLAUDE.md instructs Claude to avoid `$(...)` command substitution and use temp files via `Write` instead, so every attempt to build the review payload was being denied (3 permission denials per run)

## Test plan

- [ ] Push two commits to a PR in quick succession — only one review should appear
- [ ] Inline suggestions should now post correctly

https://fix/code-review-concurrency-and-perms--helix-tools-website--adobe.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)