### PR TITLE
feat(helix-admin): add admin.raw(); migrate site-query + bulk

### DIFF
--- a/scripts/helix-admin.js
+++ b/scripts/helix-admin.js
@@ -186,8 +186,17 @@ function createAdmin(defaults = {}) {
     return Object.fromEntries(caps.map((c) => [c, all[c]]));
   }
 
+  function raw(method, urlOrPath, body, opts) {
+    const url = urlOrPath.startsWith('/') ? `${ADMIN_BASE}${urlOrPath}` : urlOrPath;
+    const init = { method, url, params: opts?.params };
+    if (body !== undefined && body !== null) {
+      init.body = body;
+      init.contentType = opts?.contentType ?? 'application/json';
+    }
+    return request(init);
+  }
+
   function status(coords) { return bindOperation(opBase('status', coords), ['get', 'update']); }
-  function sidekick(coords) { return bindOperation(opBase('sidekick', coords), ['get']); }
   function preview(coords) { return bindOperation(opBase('preview', coords), ['get', 'update', 'remove']); }
   function live(coords) { return bindOperation(opBase('live', coords), ['get', 'update', 'remove']); }
   function code(coords) { return bindOperation(opBase('code', coords), ['get', 'update', 'remove']); }
@@ -207,7 +216,7 @@ function createAdmin(defaults = {}) {
   }
 
   return {
-    config, status, sidekick, preview, live, code, log, index, sitemap, job, withRequestInit,
+    config, status, preview, live, code, log, index, sitemap, job, raw, withRequestInit,
   };
 }
 

--- a/scripts/helix-admin.js
+++ b/scripts/helix-admin.js
@@ -187,6 +187,7 @@ function createAdmin(defaults = {}) {
   }
 
   function status(coords) { return bindOperation(opBase('status', coords), ['get', 'update']); }
+  function sidekick(coords) { return bindOperation(opBase('sidekick', coords), ['get']); }
   function preview(coords) { return bindOperation(opBase('preview', coords), ['get', 'update', 'remove']); }
   function live(coords) { return bindOperation(opBase('live', coords), ['get', 'update', 'remove']); }
   function code(coords) { return bindOperation(opBase('code', coords), ['get', 'update', 'remove']); }
@@ -206,7 +207,7 @@ function createAdmin(defaults = {}) {
   }
 
   return {
-    config, status, preview, live, code, log, index, sitemap, job, withRequestInit,
+    config, status, sidekick, preview, live, code, log, index, sitemap, job, withRequestInit,
   };
 }
 

--- a/tests/scripts/helix-admin.test.js
+++ b/tests/scripts/helix-admin.test.js
@@ -402,16 +402,67 @@ describe('helix-admin.js', () => {
     });
   });
 
-  describe('admin.sidekick(coords)', () => {
-    it('.get(path) GETs the sidekick config', async () => {
-      await admin.sidekick({ org: 'adobe', site: 'x' }).get('config.json');
+  describe('admin.raw(method, urlOrPath, body?, opts?)', () => {
+    it('path starting with / is resolved against ADMIN_BASE', async () => {
+      await admin.raw('GET', '/sidekick/adobe/x/main/config.json');
       assert.equal(calls[0].url, 'https://admin.hlx.page/sidekick/adobe/x/main/config.json');
       assert.equal(calls[0].init.method, 'GET');
     });
 
-    it('does not expose .update or .remove', () => {
-      assert.equal(admin.sidekick({ org: 'adobe', site: 'x' }).update, undefined);
-      assert.equal(admin.sidekick({ org: 'adobe', site: 'x' }).remove, undefined);
+    it('absolute URL is passed through unchanged', async () => {
+      await admin.raw('GET', 'https://admin.hlx.page/sidekick/adobe/x/main/config.json');
+      assert.equal(calls[0].url, 'https://admin.hlx.page/sidekick/adobe/x/main/config.json');
+    });
+
+    it('forwards the method as-is', async () => {
+      await admin.raw('DELETE', '/preview/adobe/x/main/page');
+      assert.equal(calls[0].init.method, 'DELETE');
+    });
+
+    it('no body → no content-type header', async () => {
+      await admin.raw('GET', '/status/adobe/x/main');
+      assert.equal(calls[0].init.body, undefined);
+      assert.equal(calls[0].init.headers, undefined);
+    });
+
+    it('body present → defaults to application/json', async () => {
+      await admin.raw('POST', '/preview/adobe/x/main/*', '{"paths":["/"]}');
+      assert.equal(calls[0].init.body, '{"paths":["/"]}');
+      assert.equal(calls[0].init.headers.get('content-type'), 'application/json');
+    });
+
+    it('opts.contentType overrides the default', async () => {
+      await admin.raw('POST', '/preview/adobe/x/main/page', 'body', { contentType: 'text/plain' });
+      assert.equal(calls[0].init.headers.get('content-type'), 'text/plain');
+    });
+
+    it('opts.params appended as query string', async () => {
+      await admin.raw('GET', '/status/adobe/x/main', undefined, { params: { editUrl: 'auto' } });
+      const u = new URL(calls[0].url);
+      assert.equal(u.searchParams.get('editUrl'), 'auto');
+    });
+
+    it('null body treated same as undefined — no content-type', async () => {
+      await admin.raw('POST', '/preview/adobe/x/main/page', null);
+      assert.equal(calls[0].init.body, undefined);
+      assert.equal(calls[0].init.headers, undefined);
+    });
+
+    it('returns a normalized AdminResponse envelope', async () => {
+      const result = await admin.raw('GET', '/status/adobe/x/main');
+      assert.equal(typeof result.ok, 'boolean');
+      assert.equal(typeof result.status, 'number');
+      assert.equal(typeof result.text, 'function');
+      assert.equal(typeof result.json, 'function');
+      assert.equal(result.error, '');
+      assert.equal(result.request.method, 'GET');
+      assert.equal(result.request.url, 'https://admin.hlx.page/status/adobe/x/main');
+    });
+
+    it('propagates withRequestInit defaults', async () => {
+      const a = admin.withRequestInit({ credentials: 'include' });
+      await a.raw('GET', '/status/adobe/x/main');
+      assert.equal(calls[0].init.credentials, 'include');
     });
   });
 

--- a/tests/scripts/helix-admin.test.js
+++ b/tests/scripts/helix-admin.test.js
@@ -402,6 +402,19 @@ describe('helix-admin.js', () => {
     });
   });
 
+  describe('admin.sidekick(coords)', () => {
+    it('.get(path) GETs the sidekick config', async () => {
+      await admin.sidekick({ org: 'adobe', site: 'x' }).get('config.json');
+      assert.equal(calls[0].url, 'https://admin.hlx.page/sidekick/adobe/x/main/config.json');
+      assert.equal(calls[0].init.method, 'GET');
+    });
+
+    it('does not expose .update or .remove', () => {
+      assert.equal(admin.sidekick({ org: 'adobe', site: 'x' }).update, undefined);
+      assert.equal(admin.sidekick({ org: 'adobe', site: 'x' }).remove, undefined);
+    });
+  });
+
   describe('admin.preview(coords)', () => {
     it('.get(path) GETs the preview status', async () => {
       await admin.preview({ org: 'adobe', site: 'x' }).get('/en/index');

--- a/tools/bulk/scripts.js
+++ b/tools/bulk/scripts.js
@@ -283,7 +283,7 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
       const paths = urlsToUse.map((url) => new URL(url).pathname);
       const bulkResp = await executeAdminRequest(
         () => admin[operation]({ org: owner, site: repo, ref: branch })
-          .update('*', JSON.stringify({ paths, forceUpdate }), { params: adminVersionParams }),
+          .update('/*', JSON.stringify({ paths, forceUpdate }), { params: adminVersionParams }),
         { org: owner, site: repo, policy: AuthMode.PREFLIGHT_AND_RETRY },
       );
       if (!bulkResp) {
@@ -297,8 +297,11 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
         const { name } = job;
         const jobStatusPoll = window.setInterval(async () => {
           try {
-            const jobResp = await admin.job({ org: owner, site: repo, ref: branch })
-              .get(`${VERB[operation]}/${name}/details`);
+            const jobResp = await executeAdminRequest(
+              () => admin.job({ org: owner, site: repo, ref: branch })
+                .get(`${VERB[operation]}/${name}/details`),
+              { org: owner, site: repo, policy: AuthMode.NONE },
+            );
             const jobStatus = await jobResp.json();
             const {
               state,

--- a/tools/bulk/scripts.js
+++ b/tools/bulk/scripts.js
@@ -1,9 +1,10 @@
-import { ensureLogin } from '../../blocks/profile/profile.js';
-import { analyzeUrls, extractOrgSite } from './utils.js';
+import { analyzeUrls } from './utils.js';
+import admin from '../../scripts/helix-admin.js';
+import { executeAdminRequest, AuthMode } from '../../utils/admin-request.js';
 
 const log = document.getElementById('logger');
 const adminVersion = new URLSearchParams(window.location.search).get('hlx-admin-version');
-const adminVersionSuffix = adminVersion ? `?hlx-admin-version=${adminVersion}` : '';
+const adminVersionParams = adminVersion ? { 'hlx-admin-version': adminVersion } : undefined;
 
 const append = (string, status = 'unknown') => {
   const p = document.createElement('p');
@@ -227,50 +228,46 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
     return false;
   }
 
-  const { org, site } = extractOrgSite(urlsToUse[0]);
-  if (!await ensureLogin(org, site)) {
-    window.addEventListener('profile-update', ({ detail: loginInfo }) => {
-      if (loginInfo.includes(org)) {
-        e.target.querySelector('button[type="submit"]').click();
-      }
-    }, { once: true });
-    append(`Awaiting sign in to ${org}...`);
-    return false;
-  }
-
   const operation = document.getElementById('operation').dataset.value;
   const slow = document.getElementById('slow').checked;
   const forceUpdate = document.getElementById('force').checked;
 
-  const executeOperation = async (url) => {
+  const ENDPOINTS = { unpublish: 'live', unpreview: 'preview' };
+  const METHODS = { unpublish: 'DELETE', unpreview: 'DELETE' };
+
+  // Returns AdminResponse or null (login cancelled).
+  const doAdminOp = (url, policy = AuthMode.NONE) => {
     const { hostname, pathname } = new URL(url);
     const [branch, repo, owner] = hostname.split('.')[0].split('--');
-    const endpoints = {
-      unpublish: 'live',
-      unpreview: 'preview',
-    };
-    const methods = {
-      unpublish: 'DELETE',
-      unpreview: 'DELETE',
-    };
-    const endpoint = endpoints[operation] || operation;
-    const method = methods[operation] || 'POST';
-    const adminURL = `https://admin.hlx.page/${endpoint}/${owner}/${repo}/${branch}${pathname}${adminVersionSuffix}`;
-    const resp = await fetch(adminURL, {
-      method,
-    });
+    const endpoint = ENDPOINTS[operation] || operation;
+    const method = METHODS[operation] || 'POST';
+    const resource = admin[endpoint]({ org: owner, site: repo, ref: branch });
+    return executeAdminRequest(
+      () => (method === 'DELETE'
+        ? resource.remove(pathname, { params: adminVersionParams })
+        : resource.update(pathname, null, { params: adminVersionParams })),
+      { org: owner, site: repo, policy },
+    );
+  };
+
+  const logOp = (resp) => {
+    const { url: reqUrl } = resp.request;
     resp.text().then(() => {
       counter += 1;
-      append(`${counter}/${total}: ${adminURL}`, resp.status);
+      append(`${counter}/${total}: ${reqUrl}`, resp.status);
       document.getElementById('total').textContent = `${counter}/${total}`;
     });
   };
 
+  const executeOperation = async (url) => {
+    const resp = await doAdminOp(url);
+    if (resp) logOp(resp);
+  };
+
   const dequeue = async () => {
     while (urlsToUse.length) {
-      const url = urlsToUse.shift();
       // eslint-disable-next-line no-await-in-loop
-      await executeOperation(url, total);
+      await executeOperation(urlsToUse.shift());
       // eslint-disable-next-line no-await-in-loop
       if (slow) await sleep(1500);
     }
@@ -278,56 +275,46 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
 
   const doBulkOperation = async () => {
     if (total > 0) {
-      const VERB = {
-        preview: 'preview',
-        live: 'publish',
-      };
-      const { hostname } = new URL(urlsToUse[0]); // use first URL to determine project details
+      const VERB = { preview: 'preview', live: 'publish' };
+      const { hostname } = new URL(urlsToUse[0]);
       const [branch, repo, owner] = hostname.split('.')[0].split('--');
       const bulkText = `$1/${total} URL(s) bulk ${VERB[operation]}ed on ${owner}/${repo} ${forceUpdate ? '(force update)' : ''}`;
       const bulkLog = append(bulkText.replace('$1', 0));
       const paths = urlsToUse.map((url) => new URL(url).pathname);
-      const bulkResp = await fetch(`https://admin.hlx.page/${operation}/${owner}/${repo}/${branch}/*${adminVersionSuffix}`, {
-        method: 'POST',
-        body: JSON.stringify({
-          paths,
-          forceUpdate,
-        }),
-        headers: {
-          'content-type': 'application/json',
-        },
-      });
+      const bulkResp = await executeAdminRequest(
+        () => admin[operation]({ org: owner, site: repo, ref: branch })
+          .update('*', JSON.stringify({ paths, forceUpdate }), { params: adminVersionParams }),
+        { org: owner, site: repo, policy: AuthMode.PREFLIGHT_AND_RETRY },
+      );
+      if (!bulkResp) {
+        append('Sign-in cancelled');
+        return;
+      }
       if (!bulkResp.ok) {
-        append(`Failed to bulk ${VERB[operation]} ${paths.length} URLs on ${origin}: ${await bulkResp.text()}`);
+        append(`Failed to bulk ${VERB[operation]} ${paths.length} URLs on ${owner}/${repo}: ${await bulkResp.text()}`);
       } else {
         const { job } = await bulkResp.json();
         const { name } = job;
         const jobStatusPoll = window.setInterval(async () => {
           try {
-            const jobResp = await fetch(`https://admin.hlx.page/job/${owner}/${repo}/${branch}/${VERB[operation]}/${name}/details`);
+            const jobResp = await admin.job({ org: owner, site: repo, ref: branch })
+              .get(`${VERB[operation]}/${name}/details`);
             const jobStatus = await jobResp.json();
             const {
               state,
-              progress: {
-                processed = 0,
-              } = {},
+              progress: { processed = 0 } = {},
               startTime,
               stopTime,
-              data: {
-                resources = [],
-              } = {},
+              data: { resources = [] } = {},
             } = jobStatus;
             if (state === 'stopped') {
-              // job done, stop polling
               window.clearInterval(jobStatusPoll);
-              // show job summary
               resources.forEach((res) => append(`${res.path} (${res.status})`, res.status));
               bulkLog.textContent = bulkText.replace('$1', processed);
               const duration = (new Date(stopTime).valueOf()
                 - new Date(startTime).valueOf()) / 1000;
               append(`Bulk ${operation} completed in ${duration}s`);
             } else {
-              // show job progress
               bulkLog.textContent = bulkText.replace('$1', processed);
             }
           } catch (error) {
@@ -341,14 +328,20 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
   };
 
   if (['preview', 'live'].includes(operation)) {
-    // use bulk preview/publish API
     doBulkOperation();
   } else {
     append(`URLs: ${urlsToUse.length}`);
     let concurrency = ['live', 'unpublish', 'unpreview'].includes(operation) ? 40 : 3;
-    if (slow) {
-      concurrency = 1;
+    if (slow) concurrency = 1;
+
+    // Auth preflight on first URL before launching concurrent dequeues.
+    const firstResp = await doAdminOp(urlsToUse.shift(), AuthMode.PREFLIGHT_AND_RETRY);
+    if (!firstResp) {
+      append('Sign-in cancelled');
+      return false;
     }
+    logOp(firstResp);
+
     for (let i = 0; i < concurrency; i += 1) {
       dequeue();
     }

--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -137,7 +137,7 @@ function displayResult(url, matches, org, site) {
       // fallback to sidekick config if status doesn't provide edit URL
       if (!editUrl) {
         const configRes = await executeAdminRequest(
-          () => admin.sidekick({ org, site }).get('config.json'),
+          () => admin.raw('GET', `/sidekick/${org}/${site}/main/config.json`),
           { org, site },
         );
         if (!configRes) return; // login cancelled

--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -1,6 +1,8 @@
 import { registerToolReady } from '../../scripts/scripts.js';
 import { initConfigField, updateConfig } from '../../utils/config/config.js';
 import { ensureLogin } from '../../blocks/profile/profile.js';
+import admin from '../../scripts/helix-admin.js';
+import { executeAdminRequest, AuthMode } from '../../utils/admin-request.js';
 
 function getFormData(form) {
   const data = {};
@@ -124,13 +126,13 @@ function displayResult(url, matches, org, site) {
     }
 
     try {
-      const statusRes = await fetch(`https://admin.hlx.page/status/${org}/${site}/main${url.pathname}?editUrl=auto`);
+      const statusRes = await admin.status({ org, site }).get(url.pathname, { params: { editUrl: 'auto' } });
       const status = await statusRes.json();
       let editUrl = status.edit && status.edit.url;
 
       // fallback to sidekick config if status doesn't provide edit URL
       if (!editUrl) {
-        const configRes = await fetch(`https://admin.hlx.page/sidekick/${org}/${site}/main/config.json`);
+        const configRes = await admin.sidekick({ org, site }).get('config.json');
         const config = await configRes.json();
         const editUrlPattern = config.editUrl;
         if (editUrlPattern) {
@@ -271,32 +273,6 @@ async function processUrl(sitemapUrl, query, queryType, org, site) {
 
   return null;
 }
-/**
- * Fetches the live and preview host URLs for org/site.
- * @param {string} org - Organization name.
- * @param {string} site - Site name within org.
- * @returns {Promise<>} Object with `live` and `preview` hostnames.
- */
-async function fetchHosts(org, site) {
-  let status;
-  try {
-    const url = `https://admin.hlx.page/status/${org}/${site}/main`;
-    const res = await fetch(url);
-    status = res.status;
-    const json = await res.json();
-    return {
-      status,
-      live: new URL(json.live.url).host,
-      preview: new URL(json.preview.url).host,
-    };
-  } catch (error) {
-    return {
-      status,
-      live: null,
-      preview: null,
-    };
-  }
-}
 
 async function init(doc) {
   doc.querySelector('.site-query').dataset.status = 'loading';
@@ -334,9 +310,15 @@ async function init(doc) {
       disableForm(form);
 
       // fetch host config
-      const { status, live } = await fetchHosts(org, site);
-      if (!live || status !== 200) {
-        updateTableError(table, status, org, site);
+      const hostsResult = await executeAdminRequest(
+        () => admin.status({ org, site }).get(''),
+        { org, site, policy: AuthMode.PREFLIGHT_AND_RETRY },
+      );
+      if (!hostsResult) return; // login cancelled
+      const hostsJson = hostsResult.ok ? await hostsResult.json() : null;
+      const live = hostsJson?.live?.url ? new URL(hostsJson.live.url).host : null;
+      if (!live || !hostsResult.ok) {
+        updateTableError(table, hostsResult.status, org, site);
         stopButton.setAttribute('aria-hidden', 'true');
         caption.setAttribute('aria-hidden', 'true');
         return;

--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -325,7 +325,7 @@ async function init(doc) {
       if (!hostsResult) return; // login cancelled
       const hostsJson = hostsResult.ok ? await hostsResult.json() : null;
       const live = hostsJson?.live?.url ? new URL(hostsJson.live.url).host : null;
-      if (!live || !hostsResult.ok) {
+      if (!live) {
         updateTableError(table, hostsResult.status, org, site);
         stopButton.setAttribute('aria-hidden', 'true');
         caption.setAttribute('aria-hidden', 'true');

--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -126,13 +126,21 @@ function displayResult(url, matches, org, site) {
     }
 
     try {
-      const statusRes = await admin.status({ org, site }).get(url.pathname, { params: { editUrl: 'auto' } });
+      const statusRes = await executeAdminRequest(
+        () => admin.status({ org, site }).get(url.pathname, { params: { editUrl: 'auto' } }),
+        { org, site },
+      );
+      if (!statusRes) return; // login cancelled
       const status = await statusRes.json();
       let editUrl = status.edit && status.edit.url;
 
       // fallback to sidekick config if status doesn't provide edit URL
       if (!editUrl) {
-        const configRes = await admin.sidekick({ org, site }).get('config.json');
+        const configRes = await executeAdminRequest(
+          () => admin.sidekick({ org, site }).get('config.json'),
+          { org, site },
+        );
+        if (!configRes) return; // login cancelled
         const config = await configRes.json();
         const editUrlPattern = config.editUrl;
         if (editUrlPattern) {


### PR DESCRIPTION
## Summary

- **New client surface**: `admin.raw(method, urlOrPath, body?, opts?)` — path-or-URL escape hatch that routes through the shared request pipeline (inheriting `withRequestInit` defaults, returning a normalized `AdminResponse`). A leading `/` is resolved against `ADMIN_BASE`; an absolute URL is passed through unchanged.
- **Dropped `admin.sidekick()` namespace** — sidekick is an undocumented/private API and doesn't merit a first-class typed namespace. Callers use `admin.raw()` instead.
- **site-query migration**: replaced `fetchHosts()` raw fetch + manual 401 handling with `executeAdminRequest(PREFLIGHT_AND_RETRY)`; edit-link status and sidekick config fallback now use the client
- **bulk migration**: dropped the event-listener re-submit auth hack; introduced `doAdminOp(url, policy)` helper that wraps `executeAdminRequest`, gates concurrent dequeues with a single PREFLIGHT_AND_RETRY on the first URL, wraps the bulk trigger the same way; also fixed a pre-existing bug where the error message used `window.origin` instead of `${owner}/${repo}`

## API surface

```js
// added
admin.raw('GET', '/sidekick/org/site/main/config.json')  // path → ADMIN_BASE + path
admin.raw('GET', 'https://admin.hlx.page/...')            // absolute URL → passed through
admin.raw('POST', '/preview/org/site/main/*', body, { contentType, params })
```

## Migration notes

**site-query** — 3 raw admin fetches replaced:
1. `GET /status/{org}/{site}/main` (host resolution) → `executeAdminRequest(PREFLIGHT_AND_RETRY)` on `admin.status({org,site}).get('')`
2. `GET /status/{org}/{site}/main{pathname}?editUrl=auto` → `admin.status({org,site}).get(pathname, {params:{editUrl:'auto'}})`
3. `GET /sidekick/{org}/{site}/main/config.json` → `admin.raw('GET', '/sidekick/${org}/${site}/main/config.json')`

**bulk** — 3 raw admin fetches replaced + auth pattern modernised:
- Old: `ensureLogin` + re-click event listener
- New: `doAdminOp(firstUrl, PREFLIGHT_AND_RETRY)` before concurrent dequeues; `executeAdminRequest(PREFLIGHT_AND_RETRY)` wrapping the bulk trigger; remaining ops use NONE policy (auth already done)

## Tests

- Added `admin.raw()` tests (path resolution, absolute passthrough, body/contentType/params, envelope, `withRequestInit` propagation)
- Removed `admin.sidekick()` tests
- Neither site-query nor bulk has extractable pure logic beyond what's already covered — no new tool-level tests added (per TESTING.md guidance)

## Preview

https://site-query-bulk-helix-admin--helix-tools-website--adobe.aem.page/tools/site-query/index.html
https://site-query-bulk-helix-admin--helix-tools-website--adobe.aem.page/tools/bulk/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)