### PR TITLE
feat(site-admin): site-level access

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -75,10 +75,10 @@ html[data-theme="light"] {
 html[data-theme="dark"] {
   color-scheme: dark;
 
-  /* shadows need more opacity on dark backgrounds */
-  --shadow-default: 0 1px 6px 0 var(--transparent-black-800);
-  --shadow-hover: 0 2px 8px 0 var(--transparent-black-800);
-  --shadow-dragged: 0 3px 12px 0 var(--transparent-black-800);
+  /* white-tinted shadows for visibility on dark backgrounds */
+  --shadow-default: 0 1px 6px 0 var(--transparent-white-200);
+  --shadow-hover: 0 2px 8px 0 var(--transparent-white-300);
+  --shadow-dragged: 0 3px 12px 0 var(--transparent-white-400);
 }
 
 @media (width >=900px) {

--- a/tools/site-admin/helpers/site-card.js
+++ b/tools/site-admin/helpers/site-card.js
@@ -25,7 +25,7 @@ import {
  * @param {string} orgValue - Organization value
  * @returns {HTMLElement} The site card element
  */
-export default function createSiteCard(site, orgValue) {
+export default function createSiteCard(site, orgValue, options = {}) {
   const card = document.createElement('div');
   card.className = 'site-card';
   card.dataset.site = site.name;
@@ -95,6 +95,15 @@ export default function createSiteCard(site, orgValue) {
   const menuTrigger = card.querySelector('.menu-trigger');
   const menuDropdown = card.querySelector('.menu-dropdown');
   const favoriteBtn = card.querySelector('.favorite-btn');
+
+  card.addEventListener('click', (e) => {
+    if (e.target.closest('button, a, input')) return;
+    document.querySelectorAll('.site-card.selected').forEach((c) => c.classList.remove('selected'));
+    card.classList.add('selected');
+    const url = new URL(window.location.href);
+    url.searchParams.set('site', site.name);
+    window.history.replaceState({}, document.title, url.href);
+  });
 
   favoriteBtn.addEventListener('click', (e) => {
     e.stopPropagation();
@@ -215,6 +224,16 @@ export default function createSiteCard(site, orgValue) {
       if (handler) await handler(item);
     });
   });
+
+  if (options.siteOnly) {
+    ['clone', 'delete'].forEach((action) => {
+      const btn = card.querySelector(`.menu-item[data-action="${action}"]`);
+      if (btn) {
+        btn.disabled = true;
+        btn.title = 'Requires org-level access';
+      }
+    });
+  }
 
   renderPsiScores(card, site.name, orgValue);
 

--- a/tools/site-admin/site-admin.css
+++ b/tools/site-admin/site-admin.css
@@ -161,6 +161,10 @@
       box-shadow: var(--shadow-hover);
     }
 
+    &.selected {
+      box-shadow: var(--shadow-dragged);
+    }
+
     &.deleting {
       pointer-events: none;
       opacity: 0.6;

--- a/tools/site-admin/site-admin.js
+++ b/tools/site-admin/site-admin.js
@@ -278,7 +278,7 @@ const initSiteAdmin = async () => {
   const form = document.getElementById('site-admin-form');
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const { submitter } = e;
+        if (loginInfo.includes(orgValue)) submitter?.click();
     const orgValue = org.value;
     if (!orgValue) return;
 

--- a/tools/site-admin/site-admin.js
+++ b/tools/site-admin/site-admin.js
@@ -209,7 +209,8 @@ const displaySitesForOrg = async (orgValue) => {
   if (status === 200 && sites) {
     displaySites(sites);
   } else if (status === 401) {
-    const loggedIn = await ensureLogin(orgValue);
+    const siteParam = new URLSearchParams(window.location.search).get('site');
+    const loggedIn = await ensureLogin(orgValue, siteParam);
     if (loggedIn) {
       return displaySitesForOrg(orgValue);
     }
@@ -285,7 +286,8 @@ const initSiteAdmin = async () => {
     url.searchParams.set('org', orgValue);
     window.history.replaceState({}, document.title, url.href);
 
-    const loggedIn = await ensureLogin(orgValue);
+    const siteParam = new URLSearchParams(window.location.search).get('site');
+    const loggedIn = await ensureLogin(orgValue, siteParam);
     if (!loggedIn) {
       window.addEventListener('profile-update', ({ detail: loginInfo }) => {
         if (loginInfo.includes(orgValue)) submitter.click();
@@ -296,7 +298,8 @@ const initSiteAdmin = async () => {
     displaySitesForOrg(orgValue);
   });
 
-  if (org.value) document.getElementById('list').click();
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('org') && params.get('site')) document.getElementById('list').click();
 };
 
 registerToolReady(initSiteAdmin());

--- a/tools/site-admin/site-admin.js
+++ b/tools/site-admin/site-admin.js
@@ -112,7 +112,7 @@ const updateSiteCount = () => {
 
 let detailsObserver;
 
-const displaySites = (sites) => {
+const displaySites = (sites, options = {}) => {
   sitesElem.ariaHidden = false;
   sitesElem.textContent = '';
 
@@ -134,11 +134,13 @@ const displaySites = (sites) => {
           ${icon('list')}
         </button>
       </div>
-      <button class="button add-site-btn">+ Add Site</button>
+      ${!options.siteOnly ? '<button class="button add-site-btn">+ Add Site</button>' : ''}
     </div>
   `;
 
-  header.querySelector('.add-site-btn').addEventListener('click', () => openAddSiteModal(org.value, '', '', logFn));
+  if (!options.siteOnly) {
+    header.querySelector('.add-site-btn').addEventListener('click', () => openAddSiteModal(org.value, '', '', logFn));
+  }
 
   sitesElem.appendChild(header);
 
@@ -184,12 +186,18 @@ const displaySites = (sites) => {
   }, { rootMargin: '200px' });
 
   sortedSites.forEach((site) => {
-    const card = createSiteCard(site, org.value);
+    const card = createSiteCard(site, org.value, options);
     grid.appendChild(card);
     detailsObserver.observe(card);
   });
 
   sitesElem.appendChild(grid);
+
+  const selectedSite = new URLSearchParams(window.location.search).get('site');
+  if (selectedSite) {
+    const selectedCard = findCardBySite(selectedSite);
+    if (selectedCard) selectedCard.classList.add('selected');
+  }
 };
 
 const displaySitesForOrg = async (orgValue) => {
@@ -204,6 +212,14 @@ const displaySitesForOrg = async (orgValue) => {
     const loggedIn = await ensureLogin(orgValue);
     if (loggedIn) {
       return displaySitesForOrg(orgValue);
+    }
+  } else if (status === 403) {
+    const siteValue = document.getElementById('site')?.value;
+    if (siteValue) {
+      const siteDetails = await fetchSiteDetails(orgValue, siteValue);
+      if (siteDetails) {
+        displaySites([{ name: siteValue }], { siteOnly: true });
+      }
     }
   }
   return null;
@@ -257,12 +273,30 @@ const initSiteAdmin = async () => {
   await Promise.all(neededIcons.map(loadIcon));
   await initConfigField();
   if (!org.value) org.value = localStorage.getItem('org') || 'adobe';
-  if (org.value) {
-    const loggedIn = await ensureLogin(org.value);
-    if (loggedIn) {
-      displaySitesForOrg(org.value);
+
+  const form = document.getElementById('site-admin-form');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const { submitter } = e;
+    const orgValue = org.value;
+    if (!orgValue) return;
+
+    const url = new URL(window.location.href);
+    url.searchParams.set('org', orgValue);
+    window.history.replaceState({}, document.title, url.href);
+
+    const loggedIn = await ensureLogin(orgValue);
+    if (!loggedIn) {
+      window.addEventListener('profile-update', ({ detail: loginInfo }) => {
+        if (loginInfo.includes(orgValue)) submitter.click();
+      }, { once: true });
+      return;
     }
-  }
+
+    displaySitesForOrg(orgValue);
+  });
+
+  if (org.value) document.getElementById('list').click();
 };
 
 registerToolReady(initSiteAdmin());

--- a/tools/site-admin/site-admin.js
+++ b/tools/site-admin/site-admin.js
@@ -278,7 +278,8 @@ const initSiteAdmin = async () => {
   const form = document.getElementById('site-admin-form');
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-        if (loginInfo.includes(orgValue)) submitter?.click();
+    const { submitter } = e;
+
     const orgValue = org.value;
     if (!orgValue) return;
 
@@ -290,7 +291,7 @@ const initSiteAdmin = async () => {
     const loggedIn = await ensureLogin(orgValue, siteParam);
     if (!loggedIn) {
       window.addEventListener('profile-update', ({ detail: loginInfo }) => {
-        if (loginInfo.includes(orgValue)) submitter.click();
+        if (loginInfo.includes(orgValue)) submitter?.click();
       }, { once: true });
       return;
     }


### PR DESCRIPTION
- Fall back to site-level permissions when user lacks org-level access; show single site card with clone/delete disabled
- Resubmit form automatically after login via profile-update event
- Set `org` param on form submit; set `site` param on card click and restore selected state on load
- Highlight selected card with drop shadow

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/site-admin/index.html
- After: https://site-admin-site-level-access--helix-tools-website--adobe.aem.live/tools/site-admin/index.html
