### PR TITLE
fix(optel): preserve port for localhost in URL selector

### DIFF
--- a/tools/optel/oversight/elements/url-selector.js
+++ b/tools/optel/oversight/elements/url-selector.js
@@ -127,14 +127,11 @@ export default class URLSelector extends HTMLElement {
       let domain = event.detail;
       try {
         // First, try to parse as a full URL
-        if (domain.startsWith('http://') || domain.startsWith('https://')) {
-          const url = new URL(domain);
-          domain = url.hostname;
-        } else {
-          // If not a full URL, treat as hostname/domain
-          const entered = new URL(`https://${domain}`);
-          domain = entered.hostname;
-        }
+        const url = (domain.startsWith('http://') || domain.startsWith('https://'))
+          ? new URL(domain)
+          : new URL(`https://${domain}`);
+        // Port is significant on localhost, but normalized away elsewhere.
+        domain = url.hostname === 'localhost' ? url.host : url.hostname;
       } catch (e) {
         // ignore, some domains are not valid URLs
       }


### PR DESCRIPTION
## Summary
- The explorer URL field stripped the port via `url.hostname`, so typing `localhost:3000` was rewritten to `localhost`. This broke RUM inspection of local dev servers, even though the URL parameter form (`?domain=localhost%3A3000`) works fine.
- Use `url.host` only when the hostname is `localhost`; other domains keep the existing port-normalization behavior.

## Test plan
- [ ] Visit https://fix-optel-localhost-port--helix-tools-website--adobe.aem.page/tools/optel/oversight/explorer.html
- [ ] Type `localhost:3000` into the URL field, press Enter — URL updates to `?domain=localhost%3A3000`, port preserved
- [ ] Type `https://example.com:8080` into the URL field — URL updates to `?domain=example.com`, port stripped (unchanged behavior)
- [ ] Type `www.aem.live` — URL updates to `?domain=www.aem.live` (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)