### PR TITLE
fix(optel): preserve port for localhost in explorer URL selector

### DIFF
--- a/tests/install-dom.js
+++ b/tests/install-dom.js
@@ -10,4 +10,6 @@ if (typeof global.document === 'undefined') {
   });
   global.window = dom.window;
   global.document = dom.window.document;
+  global.HTMLElement = dom.window.HTMLElement;
+  global.customElements = dom.window.customElements;
 }

--- a/tests/tools/optel/oversight/incognito-checkbox.test.js
+++ b/tests/tools/optel/oversight/incognito-checkbox.test.js
@@ -1,0 +1,79 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchDomainKey } from '../../../../tools/optel/oversight/elements/incognito-checkbox.js';
+
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_LOCALSTORAGE = global.localStorage;
+
+function mockLocalStorage(token) {
+  global.localStorage = {
+    getItem: (k) => (k === 'rum-bundler-token' ? token : null),
+    setItem: () => {},
+    removeItem: () => {},
+  };
+}
+
+function mockFetch(handler) {
+  const calls = [];
+  global.fetch = async (url, opts) => {
+    calls.push({ url, opts });
+    return handler(url, opts);
+  };
+  return calls;
+}
+
+describe('optel/oversight: fetchDomainKey', () => {
+  beforeEach(() => {
+    mockLocalStorage('test-token');
+  });
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    global.localStorage = ORIGINAL_LOCALSTORAGE;
+  });
+
+  it('issues key for plain domain', async () => {
+    const calls = mockFetch(async () => ({
+      status: 200,
+      json: async () => ({ domainkey: 'KEY-FOR-EXAMPLE' }),
+    }));
+    const key = await fetchDomainKey('www.example.com');
+    assert.strictEqual(calls[0].url, 'https://bundles.aem.page/domainkey/www.example.com');
+    assert.strictEqual(key, 'KEY-FOR-EXAMPLE');
+  });
+
+  it('preserves the port when issuing key for localhost:5710', async () => {
+    const calls = mockFetch(async () => ({
+      status: 200,
+      json: async () => ({ domainkey: 'KEY-FOR-LOCALHOST-5710' }),
+    }));
+    const key = await fetchDomainKey('localhost:5710');
+    assert.strictEqual(
+      calls[0].url,
+      'https://bundles.aem.page/domainkey/localhost:5710',
+      'fetch URL must include the port — bundler distinguishes localhost from localhost:5710',
+    );
+    assert.strictEqual(key, 'KEY-FOR-LOCALHOST-5710');
+  });
+
+  it('uses orgs/{org}/key only for :all suffix', async () => {
+    const calls = mockFetch(async () => ({
+      status: 200,
+      json: async () => ({ orgkey: 'ORG-KEY' }),
+    }));
+    const key = await fetchDomainKey('adobe:all');
+    assert.strictEqual(calls[0].url, 'https://bundles.aem.page/orgs/adobe/key');
+    assert.strictEqual(key, 'ORG-KEY');
+  });
+
+  it('does not treat localhost:5710 as an org', async () => {
+    const calls = mockFetch(async () => ({
+      status: 200,
+      json: async () => ({ domainkey: 'KEY' }),
+    }));
+    await fetchDomainKey('localhost:5710');
+    assert.ok(
+      !calls[0].url.includes('/orgs/'),
+      `should not hit /orgs/ for localhost:5710 — got ${calls[0].url}`,
+    );
+  });
+});

--- a/tests/tools/optel/oversight/link-facet.test.js
+++ b/tests/tools/optel/oversight/link-facet.test.js
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { labelURLParts } from '../../../../tools/optel/oversight/elements/link-facet.js';
+
+describe('optel/oversight: labelURLParts', () => {
+  it('renders parts for a https url', () => {
+    const html = labelURLParts('https://example.com/path', '', true);
+    assert.match(html, /<span class="protocol"[^>]*>https:<\/span>/);
+    assert.match(html, /<span class="hostname"[^>]*>example\.com<\/span>/);
+    assert.match(html, /<span class="pathname"[^>]*>\/path<\/span>/);
+  });
+
+  it('renders the port for http://localhost:5710/path', () => {
+    const html = labelURLParts('http://localhost:5710/path', '', true);
+    assert.match(html, /<span class="hostname"[^>]*>localhost<\/span>/);
+    assert.match(
+      html,
+      /<span class="port"[^>]*>5710<\/span>/,
+      'port should be rendered as its own span — without it the rendered URL silently drops :5710',
+    );
+    assert.match(html, /<span class="pathname"[^>]*>\/path<\/span>/);
+  });
+
+  it('keeps the port when collapsing against a prefix', () => {
+    const html = labelURLParts(
+      'http://localhost:5710/foo/bar',
+      'http://localhost:5710/',
+      false,
+    );
+    assert.match(html, /class="collapse"/);
+    assert.match(html, /title="http:\/\/localhost:5710\/foo\/bar"/);
+  });
+
+  it('preserves : in the displayed URL when no prefix', () => {
+    const html = labelURLParts('http://localhost:5710/foo', '', false);
+    assert.ok(
+      html.includes('5710'),
+      `expected port 5710 in rendered output, got: ${html}`,
+    );
+  });
+});

--- a/tools/optel/explorer/elements/url-selector.js
+++ b/tools/optel/explorer/elements/url-selector.js
@@ -134,14 +134,11 @@ export default class URLSelector extends HTMLElement {
       let domain = event.detail;
       try {
         // First, try to parse as a full URL
-        if (domain.startsWith('http://') || domain.startsWith('https://')) {
-          const url = new URL(domain);
-          domain = url.hostname;
-        } else {
-          // If not a full URL, treat as hostname/domain
-          const entered = new URL(`https://${domain}`);
-          domain = entered.hostname;
-        }
+        const url = (domain.startsWith('http://') || domain.startsWith('https://'))
+          ? new URL(domain)
+          : new URL(`https://${domain}`);
+        // Port is significant on localhost, but normalized away elsewhere.
+        domain = url.hostname === 'localhost' ? url.host : url.hostname;
       } catch (e) {
         // ignore, some domains are not valid URLs
       }

--- a/tools/optel/oversight/elements/incognito-checkbox.js
+++ b/tools/optel/oversight/elements/incognito-checkbox.js
@@ -2,7 +2,7 @@ function getPersistentToken() {
   return localStorage.getItem('rum-bundler-token');
 }
 
-async function fetchDomainKey(domain) {
+export async function fetchDomainKey(domain) {
   try {
     const auth = getPersistentToken();
     let org;

--- a/tools/optel/oversight/elements/link-facet.js
+++ b/tools/optel/oversight/elements/link-facet.js
@@ -10,7 +10,7 @@ function urlDecode(part, rich = false) {
     : part.replace(/%3[Cc](number|hex|base64|uuid)%3[Ee]/g, '<$1>');
 }
 
-function labelURLParts(url, prefix, solo = false) {
+export function labelURLParts(url, prefix, solo = false) {
   if (prefix && url.startsWith(prefix) && !solo) {
     return `<span class="collapse" title="${escapeHTML(url)}">${escapeHTML(prefix)}</span><span class="suffix" title="${escapeHTML(urlDecode(url))}">${urlDecode(escapeHTML(url.replace(prefix, '')), true)}</span>`;
   }


### PR DESCRIPTION
## Summary
The optel explorer ships in two parallel copies — `tools/optel/oversight/` and `tools/optel/explorer/` — with diverging element implementations. PR #355 fixed the URL selector's submit handler in `oversight/`, but the `explorer/` copy still strips the port via `url.hostname`. So a user typing `localhost:5710` into the `explorer/` URL field still gets rewritten to bare `localhost`, and the auto-retrieved domainkey ends up scoped to `localhost`, not `localhost:5710`.

The diff between the two `url-selector.js` copies is large (different domain-suggestion handling, different shift-click flows), so they aren't trivially de-dupable here. This PR just ports the one-line guard from PR #355 to the `explorer/` copy.

## Change
- `tools/optel/explorer/elements/url-selector.js`: same fix as PR #355 — preserve `url.host` (port included) when `url.hostname === 'localhost'`.
- `tools/optel/oversight/elements/incognito-checkbox.js`, `tools/optel/oversight/elements/link-facet.js`: export `fetchDomainKey` and `labelURLParts` for testability. No behavior change.
- `tests/install-dom.js`: expose `HTMLElement` and `customElements` from JSDOM so element modules import cleanly under the Node test runner.
- New tests:
  - `tests/tools/optel/oversight/incognito-checkbox.test.js` — locks in that `fetchDomainKey('localhost:5710')` calls `/domainkey/localhost:5710` and that `:all` (org) parsing still works.
  - `tests/tools/optel/oversight/link-facet.test.js` — locks in that `labelURLParts` renders the port for `http://localhost:5710/path`.

## Test plan
- [ ] Visit https://fix-optel-explorer-localhost-port--helix-tools-website--adobe.aem.page/tools/optel/explorer/explorer.html
- [ ] Type `localhost:5710` into the URL field, press Enter — URL should become `?domain=localhost%3A5710`, port preserved
- [ ] Same on `oversight/explorer.html` (regression check) — should still work as PR #355 fixed
- [x] `npm test` passes (193 tests, 0 failures)
- [x] `npm run lint` shows no new issues (1 pre-existing error in cdn-check.js unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)