### PR TITLE
feat(cdn-check): migrate admin config fetch to shared helix-admin client

### DIFF
--- a/tools/cdn-check/cdn-check.js
+++ b/tools/cdn-check/cdn-check.js
@@ -940,7 +940,7 @@ async function checkCdnConfig(org, site, sharedCdnProd = null) {
 
   try {
     const result = await executeAdminRequest(
-      () => admin.raw('GET', `/config/${org}/aggregated/${site}.json`),
+      () => admin.config({ org }).select('aggregated').select(`${site}.json`).read(),
       { org, site, policy: AuthMode.PREFLIGHT_AND_RETRY },
     );
 

--- a/tools/cdn-check/cdn-check.js
+++ b/tools/cdn-check/cdn-check.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-await-in-loop -- sequential awaits required: DNS DoH provider fallback chain,
  * IP metadata provider chain (ipwho → ipapi → RDAP), and ordered CDN checks must not race. */
-import { ensureLogin } from '../../blocks/profile/profile.js';
 import classifyIpNetwork from './cdn-check-network.js';
+import admin from '../../scripts/helix-admin.js';
+import { executeAdminRequest, AuthMode } from '../../utils/admin-request.js';
 
 // CORS proxy for cross-origin requests (fcors.org). The key is sent as a query param on
 // every proxied request and is visible in DevTools — it is not a server secret. It exists
@@ -938,19 +939,27 @@ async function checkCdnConfig(org, site, sharedCdnProd = null) {
   }
 
   try {
-    const configUrl = `https://admin.hlx.page/config/${org}/aggregated/${site}.json`;
-    const resp = await fetch(configUrl);
+    const result = await executeAdminRequest(
+      () => admin.raw('GET', `/config/${org}/aggregated/${site}.json`),
+      { org, site, policy: AuthMode.PREFLIGHT_AND_RETRY },
+    );
 
-    if (!resp.ok) {
-      if (handleAuthError(resp.status, checkId)) {
+    if (!result) {
+      updateCheckState(checkId, 'fail', 'Sign In Required');
+      addResultLine(checkId, 'Sign in is required to check this project.', 'error');
+      return { score: 0, cdnConfig: null, authError: true };
+    }
+
+    if (!result.ok) {
+      if (handleAuthError(result.status, checkId)) {
         return { score: 0, cdnConfig: null, authError: true };
       }
       updateCheckState(checkId, 'fail', 'Failed');
-      addResultLine(checkId, `Failed to fetch config: ${resp.status}`, 'error');
+      addResultLine(checkId, `Failed to fetch config: ${result.status}`, 'error');
       return { score: 0, cdnConfig: null };
     }
 
-    const config = await resp.json();
+    const config = await result.json();
     const cdnConfig = config.cdn?.prod;
     return materializeCdnProdCheckResult(cdnConfig);
   } catch (e) {
@@ -1746,17 +1755,6 @@ async function runChecks(pageUrl, prodPageUrl = null) {
   const { cdnProd: sharedCdnProd, purgeReport: sharedPurgeSnapshot } = parseCdnProdShareFromSearch(
     new URLSearchParams(window.location.search),
   );
-
-  // Ensure login (skip when cdn.prod was supplied in the URL — no admin.hlx.page fetch)
-  if (!sharedCdnProd && !await ensureLogin(org, site)) {
-    // Wait for login event
-    window.addEventListener('profile-update', async ({ detail: loginInfo }) => {
-      if (loginInfo.includes(org)) {
-        runChecks(pageUrl, prodPageUrl);
-      }
-    }, { once: true });
-    return;
-  }
 
   const prodForGate = prodPageUrl && String(prodPageUrl).trim();
   if (prodForGate) {


### PR DESCRIPTION
## Summary

- Replaces the bare `fetch('https://admin.hlx.page/config/{org}/aggregated/{site}.json')` in `checkCdnConfig` with `admin.config({ org }).select('aggregated').select(\`${site}.json\`).read()` from the shared `helix-admin.js` client
- Wraps the call with `executeAdminRequest(..., { policy: AuthMode.PREFLIGHT_AND_RETRY })` from `utils/admin-request.js`, matching the pattern used by `tools/user-admin`
- Removes the one-off `ensureLogin` gate + `profile-update` re-run listener from `runChecks` — auth preflight and 401 retry are now handled uniformly by the shared utility
- The `sharedCdnProd` skip behavior is preserved: the existing early return in `checkCdnConfig` means `executeAdminRequest` is never reached when CDN config is supplied via share link URL

## Preview

https://cdn-check-admin--helix-tools-website--adobe.aem.page/tools/cdn-check/index.html

## Test plan

- [ ] Open the preview URL and run a CDN check against a known site — verify the CDN config step completes successfully
- [ ] Sign out, run a check — verify the login prompt appears and checks proceed after signing in
- [ ] Cancel the login prompt — verify "Sign In Required" is shown for CDN config and remaining checks are skipped
- [ ] Run a check with a `?cdnProd=...` share link — verify no auth prompt appears and results render from the query param as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)