### PR TITLE
feat(site-admin): validate site name and preview domain when creating a site

### DIFF
--- a/tools/site-admin/helpers/modals.js
+++ b/tools/site-admin/helpers/modals.js
@@ -9,6 +9,19 @@ import {
 
 /* eslint-disable no-alert, no-restricted-globals */
 
+// Preview/live hostnames follow `{branch}--{site}--{org}.aem.page` and must fit
+// within the 63-character DNS label limit. We validate against the `main` branch
+// because every site has one — feature branches are warned about separately.
+const MAX_HOSTNAME_LENGTH = 63;
+const WARN_HOSTNAME_LENGTH = 58;
+const SITE_NAME_PATTERN = /^-?[a-z0-9]+(-[a-z0-9]+)*-?$/;
+
+const mainHostnameLength = (siteName, orgValue) => `main--${siteName}--${orgValue}`.length;
+
+const maxBranchLength = (siteName, orgValue) => (
+  MAX_HOSTNAME_LENGTH - siteName.length - orgValue.length - 4
+);
+
 const refreshSites = (orgValue, action, siteName) => {
   window.dispatchEvent(new CustomEvent('sites-refresh', { detail: { orgValue, action, siteName } }));
 };
@@ -792,9 +805,11 @@ export const openAddSiteModal = async (
     </div>
     <form class="add-site-form">
       <div class="form-field">
-        <label for="new-site-name">Site Name</label>
+        <label for="new-site-name">Site Name <span class="label-preview">(Domain Preview: <code><span class="label-domain"></span>.aem.page</code>)</span></label>
         <input type="text" id="new-site-name" required placeholder="my-site" pattern="[a-z0-9-]+" />
         <p class="field-hint">Lowercase letters, numbers, and hyphens only</p>
+        <p class="field-error" aria-hidden="true"></p>
+        <p class="field-warning" aria-hidden="true"></p>
       </div>
       <div class="form-field code-url-field"${isByogit ? ' aria-hidden="true"' : ''}>
         <label for="new-site-code">GitHub Repository URL</label>
@@ -858,6 +873,49 @@ export const openAddSiteModal = async (
   const byogitOwnerInput = container.querySelector('#new-site-byogit-owner');
   const byogitRepoInput = container.querySelector('#new-site-byogit-repo');
 
+  const siteNameInput = container.querySelector('#new-site-name');
+  const hintEl = siteNameInput.parentElement.querySelector('.field-hint');
+  const warningEl = container.querySelector('.field-warning');
+  const errorEl = container.querySelector('.field-error');
+  const labelPreviewEl = siteNameInput.parentElement.querySelector('.label-preview');
+  const labelDomainEl = labelPreviewEl.querySelector('.label-domain');
+  const createBtn = container.querySelector('.create-btn');
+  const setMessage = (el, html) => {
+    if (html) {
+      el.innerHTML = html;
+      el.setAttribute('aria-hidden', 'false');
+    } else {
+      el.textContent = '';
+      el.setAttribute('aria-hidden', 'true');
+    }
+  };
+  const validateSiteName = () => {
+    const candidate = siteNameInput.value.trim();
+    let error = '';
+    let warning = '';
+    if (candidate && !SITE_NAME_PATTERN.test(candidate)) {
+      error = 'Site names may only contain lowercase letters, numbers, and single hyphens.';
+    } else if (candidate) {
+      const length = mainHostnameLength(candidate, orgValue);
+      if (length > MAX_HOSTNAME_LENGTH) {
+        error = 'This site name exceeds the domain label limit.';
+      } else if (length > WARN_HOSTNAME_LENGTH) {
+        const branchMax = maxBranchLength(candidate, orgValue);
+        warning = `Warning: This site name will leave only ${branchMax} characters for branch names (4 characters minimum).`;
+      }
+    }
+    setMessage(errorEl, error);
+    setMessage(warningEl, warning);
+    hintEl.setAttribute('aria-hidden', error || warning ? 'true' : 'false');
+    const previewSite = candidate || siteNameInput.placeholder || 'my-site';
+    labelDomainEl.textContent = `main--${previewSite}--${orgValue}`;
+    labelPreviewEl.classList.toggle('error', !!error);
+    labelPreviewEl.classList.toggle('warning', !!warning);
+    createBtn.disabled = !candidate || !!error;
+  };
+  siteNameInput.addEventListener('input', validateSiteName);
+  validateSiteName();
+
   byogitCheckbox.addEventListener('change', () => {
     const { checked } = byogitCheckbox;
     if (checked) {
@@ -913,6 +971,20 @@ export const openAddSiteModal = async (
     const codeUrl = codeInput.value.trim();
     const contentUrl = container.querySelector('#new-site-content').value.trim();
 
+    if (siteName.startsWith('-') || siteName.endsWith('-')) {
+      setMessage(errorEl, 'Site names cannot start or end with a hyphen.');
+      setMessage(warningEl, '');
+      hintEl.setAttribute('aria-hidden', 'true');
+      return;
+    }
+
+    if (document.querySelector(`.site-card[data-site="${CSS.escape(siteName)}"]`)) {
+      setMessage(errorEl, `A site named <code>${escapeHtml(siteName)}</code> already exists.`);
+      setMessage(warningEl, '');
+      hintEl.setAttribute('aria-hidden', 'true');
+      return;
+    }
+
     let byogit = null;
     if (byogitCheckbox.checked) {
       byogit = {
@@ -921,7 +993,6 @@ export const openAddSiteModal = async (
       };
     }
 
-    const createBtn = container.querySelector('.create-btn');
     createBtn.disabled = true;
     createBtn.innerHTML = 'Creating... <i class="symbol symbol-loading"></i>';
 

--- a/tools/site-admin/helpers/modals.js
+++ b/tools/site-admin/helpers/modals.js
@@ -13,8 +13,8 @@ import {
 // within the 63-character DNS label limit. We validate against the `main` branch
 // because every site has one — feature branches are warned about separately.
 const MAX_HOSTNAME_LENGTH = 63;
-const WARN_HOSTNAME_LENGTH = 58;
-const SITE_NAME_PATTERN = /^-?[a-z0-9]+(-[a-z0-9]+)*-?$/;
+const WARN_HOSTNAME_LENGTH = 56;
+const SITE_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*-?$/;
 
 const mainHostnameLength = (siteName, orgValue) => `main--${siteName}--${orgValue}`.length;
 
@@ -808,8 +808,8 @@ export const openAddSiteModal = async (
         <label for="new-site-name">Site Name <span class="label-preview">(Domain Preview: <code><span class="label-domain"></span>.aem.page</code>)</span></label>
         <input type="text" id="new-site-name" required placeholder="my-site" pattern="[a-z0-9-]+" />
         <p class="field-hint">Lowercase letters, numbers, and hyphens only</p>
-        <p class="field-error" aria-hidden="true"></p>
-        <p class="field-warning" aria-hidden="true"></p>
+        <p class="field-error" role="alert" aria-hidden="true"></p>
+        <p class="field-warning" aria-live="polite" aria-hidden="true"></p>
       </div>
       <div class="form-field code-url-field"${isByogit ? ' aria-hidden="true"' : ''}>
         <label for="new-site-code">GitHub Repository URL</label>
@@ -894,14 +894,14 @@ export const openAddSiteModal = async (
     let error = '';
     let warning = '';
     if (candidate && !SITE_NAME_PATTERN.test(candidate)) {
-      error = 'Site names may only contain lowercase letters, numbers, and single hyphens.';
+      error = 'Site names may only contain lowercase letters, numbers, and single hyphens, and cannot start with a hyphen.';
     } else if (candidate) {
       const length = mainHostnameLength(candidate, orgValue);
       if (length > MAX_HOSTNAME_LENGTH) {
         error = 'This site name exceeds the domain label limit.';
       } else if (length > WARN_HOSTNAME_LENGTH) {
         const branchMax = maxBranchLength(candidate, orgValue);
-        warning = `Warning: This site name will leave only ${branchMax} characters for branch names (4 characters minimum).`;
+        warning = `Warning: This site name will leave only ${branchMax} characters for branch names (4 characters minimum to accommodate <code>main</code>).`;
       }
     }
     setMessage(errorEl, error);
@@ -971,8 +971,8 @@ export const openAddSiteModal = async (
     const codeUrl = codeInput.value.trim();
     const contentUrl = container.querySelector('#new-site-content').value.trim();
 
-    if (siteName.startsWith('-') || siteName.endsWith('-')) {
-      setMessage(errorEl, 'Site names cannot start or end with a hyphen.');
+    if (siteName.endsWith('-')) {
+      setMessage(errorEl, 'Site names cannot end with a hyphen.');
       setMessage(warningEl, '');
       hintEl.setAttribute('aria-hidden', 'true');
       return;

--- a/tools/site-admin/site-admin.css
+++ b/tools/site-admin/site-admin.css
@@ -783,17 +783,51 @@
   color: var(--color-font-grey);
 }
 
+.site-modal .label-preview {
+  color: var(--color-font-grey);
+  word-break: break-all;
+}
+
+.site-modal .label-preview.warning .label-domain {
+  color: light-dark(var(--yellow-900), var(--yellow-500));
+}
+
+.site-modal .label-preview.error .label-domain {
+  color: var(--red-800);
+}
+
 .site-modal .field-error {
   margin: var(--spacing-xs) 0 0;
   font-size: var(--body-size-xs);
   color: var(--red-800);
 }
 
-.site-modal .field-hint code {
+.site-modal .field-warning {
+  margin: var(--spacing-xs) 0 0;
+  font-size: var(--body-size-xs);
+  color: light-dark(var(--yellow-900), var(--yellow-500));
+}
+
+.site-modal .field-hint[aria-hidden="true"],
+.site-modal .field-error[aria-hidden="true"],
+.site-modal .field-warning[aria-hidden="true"] {
+  display: none;
+}
+
+.site-modal .field-error[aria-hidden="false"],
+.site-modal .field-warning[aria-hidden="false"] {
+  display: block;
+}
+
+.site-modal .field-hint code,
+.site-modal .field-error code,
+.site-modal .field-warning code,
+.site-modal .label-preview code {
   background: var(--color-button-accent-bg);
   padding: 1px 4px;
   border-radius: 3px;
   font-size: 0.85em;
+  word-break: break-all;
 }
 
 .site-modal .auth-loading,


### PR DESCRIPTION
## Summary
Adds validation, an inline domain preview, and accessibility hooks to the Add Site modal in `site-admin`.

### Live validation (on input)
Create Site button is disabled while the field is empty or in an error state.

- **Character set:** lowercase letters, numbers, single hyphens. No consecutive `--`, no leading hyphen.
- **Hostname length** (against `main--{site}--{org}` against the 63-char DNS label limit):
  - **Warning** when the remaining budget for branch names is ≤ 10 chars — first label in the preview turns amber.
  - **Error** when the hostname already exceeds 63 chars — first label turns red, button disabled.

### Submit-time validation
- **Trailing hyphen** — hyphens are common while typing site names, so this is only checked on submit.
- **Duplicate site name** — checked against existing `.site-card[data-site]` entries.

Both surface an inline red error in the shared message slot and clear any active warning.

### Domain preview
Field label shows `(Domain Preview: main--{site}--{org}.aem.page)`, updated live via stable text-node writes (no `innerHTML` reparse per keystroke).

### Accessibility
- `role="alert"` on the error element (assertive announcement for blocking errors).
- `aria-live="polite"` on the warning element (queued announcement, doesn't interrupt typing).

### Layout
Hint, warning, and error share a single vertical slot — only one is visible at a time, so the form doesn't grow/shrink as validation state changes.

Preview: https://create-site-checks--helix-tools-website--adobe.aem.page/tools/site-admin/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)