### PR TITLE
OpTel Oversight monthly aggregate

### DIFF
--- a/tools/optel/oversight/charts/cwvperf.js
+++ b/tools/optel/oversight/charts/cwvperf.js
@@ -53,7 +53,9 @@ export default class CWVPerfChart extends AbstractChart {
         if (this.chartConfig.unit === 'day') startDate.setDate(endDate.getDate() - 30);
         if (this.chartConfig.unit === 'hour') startDate.setDate(endDate.getDate() - 7);
         if (this.chartConfig.unit === 'week') startDate.setMonth(endDate.getMonth() - 12);
-        if (this.chartConfig.unit === 'month') startDate.setMonth(endDate.getMonth() - 1);
+        if (this.chartConfig.unit === 'month') {
+          startDate.setMonth(endDate.getMonth() - (this.chartConfig.units || 1));
+        }
       } else {
         startDate = new Date(this.chartConfig.startDate);
       }
@@ -316,6 +318,14 @@ export default class CWVPerfChart extends AbstractChart {
         view,
         unit: 'week',
         units: 52,
+        focus,
+        startDate,
+        endDate,
+      },
+      '2years': {
+        view,
+        unit: 'month',
+        units: 24,
         focus,
         startDate,
         endDate,

--- a/tools/optel/oversight/charts/redirectperf.js
+++ b/tools/optel/oversight/charts/redirectperf.js
@@ -57,7 +57,9 @@ export default class RedirectPerfChart extends AbstractChart {
         if (this.chartConfig.unit === 'day') startDate.setDate(endDate.getDate() - 30);
         if (this.chartConfig.unit === 'hour') startDate.setDate(endDate.getDate() - 7);
         if (this.chartConfig.unit === 'week') startDate.setMonth(endDate.getMonth() - 12);
-        if (this.chartConfig.unit === 'month') startDate.setMonth(endDate.getMonth() - 1);
+        if (this.chartConfig.unit === 'month') {
+          startDate.setMonth(endDate.getMonth() - (this.chartConfig.units || 1));
+        }
       } else {
         startDate = new Date(this.chartConfig.startDate);
       }
@@ -295,6 +297,9 @@ export default class RedirectPerfChart extends AbstractChart {
       },
       year: {
         view, unit: 'week', units: 52, focus, startDate, endDate,
+      },
+      '2years': {
+        view, unit: 'month', units: 24, focus, startDate, endDate,
       },
       custom: {
         view: customView, unit, units, focus, startDate, endDate,

--- a/tools/optel/oversight/charts/skyline.js
+++ b/tools/optel/oversight/charts/skyline.js
@@ -59,7 +59,9 @@ export default class SkylineChart extends AbstractChart {
         if (this.chartConfig.unit === 'day') startDate.setDate(endDate.getDate() - 30);
         if (this.chartConfig.unit === 'hour') startDate.setDate(endDate.getDate() - 7);
         if (this.chartConfig.unit === 'week') startDate.setMonth(endDate.getMonth() - 12);
-        if (this.chartConfig.unit === 'month') startDate.setMonth(endDate.getMonth() - 1);
+        if (this.chartConfig.unit === 'month') {
+          startDate.setMonth(endDate.getMonth() - (this.chartConfig.units || 1));
+        }
       } else {
         startDate = new Date(this.chartConfig.startDate);
       }
@@ -599,6 +601,14 @@ export default class SkylineChart extends AbstractChart {
         view,
         unit: 'week',
         units: 52,
+        focus,
+        startDate,
+        endDate,
+      },
+      '2years': {
+        view,
+        unit: 'month',
+        units: 24,
         focus,
         startDate,
         endDate,

--- a/tools/optel/oversight/cwvperf.html
+++ b/tools/optel/oversight/cwvperf.html
@@ -68,6 +68,7 @@
                   <li data-value="week">Last week</li>
                   <li data-value="month" aria-selected="true">Last month</li>
                   <li data-value="year">Last year</li>
+                  <li data-value="2years">Last 2 years</li>
                   <li data-value="custom">Custom</li>
                 </ul>
               </daterange-picker>

--- a/tools/optel/oversight/elements/daterange-picker.js
+++ b/tools/optel/oversight/elements/daterange-picker.js
@@ -352,7 +352,7 @@ export default class DateRangePicker extends HTMLElement {
     // Sanitize value to prevent XSS in querySelector
     // CSS.escape would be ideal but use a safe approach for browser compatibility
     // Only allow known valid values to prevent injection
-    const validValues = ['week', 'month', 'year', 'custom'];
+    const validValues = ['week', 'month', 'year', '2years', 'custom'];
     const sanitizedValue = validValues.includes(value) ? value : '';
     const option = sanitizedValue ? dropdownElement.querySelector(`li[data-value="${sanitizedValue}"]`) : null;
     if (!option) {
@@ -431,6 +431,11 @@ export default class DateRangePicker extends HTMLElement {
       const lastYear = new Date(now);
       lastYear.setFullYear(now.getFullYear() - 1);
       fromElement.value = toDateString(lastYear);
+      toElement.value = toDateString(now);
+    } else if (value === '2years') {
+      const last2Years = new Date(now);
+      last2Years.setFullYear(now.getFullYear() - 2);
+      fromElement.value = toDateString(last2Years);
       toElement.value = toDateString(now);
     } else if (value === 'custom') {
       [fromElement, toElement].forEach((field) => {

--- a/tools/optel/oversight/explorer.html
+++ b/tools/optel/oversight/explorer.html
@@ -68,6 +68,7 @@
                 <li data-value="week">Last week</li>
                 <li data-value="month" aria-selected="true">Last month</li>
                 <li data-value="year">Last year</li>
+                <li data-value="2years">Last 2 years</li>
                 <li data-value="custom">Custom</li>
               </ul>
             </daterange-picker>

--- a/tools/optel/oversight/flow.html
+++ b/tools/optel/oversight/flow.html
@@ -69,6 +69,7 @@
                 <li data-value="week">Last week</li>
                 <li data-value="month" aria-selected="true">Last month</li>
                 <li data-value="year">Last year</li>
+                <li data-value="2years">Last 2 years</li>
                 <li data-value="custom">Custom</li>
               </ul>
             </daterange-picker>

--- a/tools/optel/oversight/list.html
+++ b/tools/optel/oversight/list.html
@@ -65,6 +65,7 @@
                 <li data-value="week">Last week</li>
                 <li data-value="month" aria-selected="true">Last month</li>
                 <li data-value="year">Last year</li>
+                <li data-value="2years">Last 2 years</li>
                 <li data-value="custom">Custom</li>
               </ul>
             </daterange-picker>

--- a/tools/optel/oversight/loader.js
+++ b/tools/optel/oversight/loader.js
@@ -144,6 +144,18 @@ export default class DataLoader {
     return chunks;
   }
 
+  async fetchPrevious24Months(endDate) {
+    const date = endDate ? new Date(endDate) : new Date();
+    const months = 25; // 25 to include 2 partial months (first and last)
+    const promises = [];
+    for (let i = 0; i < months; i += 1) {
+      promises.push(this.fetchUTCMonth(date.toISOString()));
+      date.setUTCMonth(date.getUTCMonth() - 1, 1);
+    }
+    const chunks = Promise.all(promises);
+    return chunks;
+  }
+
   async fetchDateRange(startDate, endDate = new Date().toISOString()) {
     const start = new Date(startDate);
     const end = new Date(endDate);

--- a/tools/optel/oversight/redirectperf.html
+++ b/tools/optel/oversight/redirectperf.html
@@ -68,6 +68,7 @@
                   <li data-value="week">Last week</li>
                   <li data-value="month" aria-selected="true">Last month</li>
                   <li data-value="year">Last year</li>
+                  <li data-value="2years">Last 2 years</li>
                   <li data-value="custom">Custom</li>
                 </ul>
               </daterange-picker>

--- a/tools/optel/oversight/share.html
+++ b/tools/optel/oversight/share.html
@@ -68,6 +68,7 @@
                 <li data-value="week">Last week</li>
                 <li data-value="month" aria-selected="true">Last month</li>
                 <li data-value="year">Last year</li>
+                <li data-value="2years">Last 2 years</li>
                 <li data-value="custom">Custom</li>
               </ul>
             </daterange-picker>

--- a/tools/optel/oversight/slicer.js
+++ b/tools/optel/oversight/slicer.js
@@ -422,6 +422,8 @@ async function loadData(config) {
     dataChunks.load(await loader.fetchPrevious31Days(endDate));
   } else if (scope === 'year') {
     dataChunks.load(await loader.fetchPrevious12Months(endDate));
+  } else if (scope === '2years') {
+    dataChunks.load(await loader.fetchPrevious24Months(endDate));
   }
 }
 

--- a/tools/optel/oversight/table.html
+++ b/tools/optel/oversight/table.html
@@ -67,6 +67,7 @@
                 <li data-value="week">Last week</li>
                 <li data-value="month" aria-selected="true">Last month</li>
                 <li data-value="year">Last year</li>
+                <li data-value="2years">Last 2 years</li>
                 <li data-value="custom">Custom</li>
               </ul>
             </daterange-picker>


### PR DESCRIPTION
Select "2 years" from timeframe dropdown in OpTel Explorer and see skyline chart grouped by month instead of week.

<img width="1712" height="1084" alt="optel-oversight-skyline-emigrationbrewing com" src="https://github.com/user-attachments/assets/1d88924a-e49a-41ff-aa9a-cbf75ff4e02d" />

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/optel/oversight/explorer.html?domain=emigrationbrewing.com&view=month&domainkey=open
- After: https://optel-monthly-bars--helix-tools-website--adobe.aem.live/tools/optel/oversight/explorer.html?domain=emigrationbrewing.com&view=2years&domainkey=open
