### PR TITLE
feat(index-admin): Improve property editor and dialog UX

### DIFF
--- a/tools/index-admin/index-admin.css
+++ b/tools/index-admin/index-admin.css
@@ -419,7 +419,6 @@
         display: flex;
         justify-content: flex-end;
         padding: var(--spacing-s) var(--spacing-m);
-        border-top: 1px solid var(--color-border);
         background: var(--color-background);
         flex-shrink: 0;
 

--- a/tools/index-admin/index-admin.css
+++ b/tools/index-admin/index-admin.css
@@ -178,6 +178,20 @@
         color: var(--color-text);
         font-size: var(--heading-size-l);
       }
+
+      .index-dialog-context {
+        margin: var(--spacing-s) 0 0;
+        color: var(--color-font-grey);
+        font-size: 0.875rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--spacing-xs) var(--spacing-l);
+
+        strong {
+          color: var(--color-font-grey);
+          font-weight: 600;
+        }
+      }
     }
 
     .index-details-body {
@@ -260,10 +274,6 @@
           font-size: 0.875rem;
           margin: 0;
         }
-
-        .add-property-btn {
-          font-size: var(--body-size-xs);
-        }
       }
 
       .properties-container {
@@ -308,10 +318,6 @@
         transition: background-color 0.2s ease;
         align-items: center;
         min-height: 48px;
-
-        &:last-child {
-          border-bottom: none;
-        }
 
         &:hover {
           background: light-dark(var(--blue-25), var(--gray-800));
@@ -406,6 +412,19 @@
               }
             }
           }
+        }
+      }
+
+      .add-property-row {
+        display: flex;
+        justify-content: flex-end;
+        padding: var(--spacing-s) var(--spacing-m);
+        border-top: 1px solid var(--color-border);
+        background: var(--color-background);
+        flex-shrink: 0;
+
+        .add-property-btn {
+          font-size: var(--body-size-xs);
         }
       }
     }

--- a/tools/index-admin/index-admin.js
+++ b/tools/index-admin/index-admin.js
@@ -77,10 +77,15 @@ function createPropertyRow(propertiesContainer, {
   const isNewRow = !propName
     && propInfo.value === undefined
     && propInfo.values === undefined;
-  valueField.value = propInfo.value
-    ?? propInfo.values?.join?.('\n')
-    ?? propInfo.values
-    ?? (isNewRow ? 'attribute(el, "content")' : '');
+  if (propInfo.value !== undefined) {
+    valueField.value = propInfo.value;
+  } else if (propInfo.values !== undefined) {
+    valueField.value = propInfo.values?.join?.('\n') ?? propInfo.values;
+  } else if (isNewRow) {
+    valueField.value = 'attribute(el, "content")';
+  } else {
+    valueField.value = '';
+  }
 
   property.querySelector('label[for="index-property-name"]').htmlFor = nameField.id;
   property.querySelector('label[for="index-property-select"]').htmlFor = selectField.id;

--- a/tools/index-admin/index-admin.js
+++ b/tools/index-admin/index-admin.js
@@ -21,12 +21,102 @@ async function ensureYaml() {
   YAML = YAML || await import('../../vendor/yaml/yaml.js');
 }
 
+const OG_META_PROPERTIES = new Set(['title', 'description', 'image']);
+
+function metaSelectFirstForProperty(propName) {
+  const name = propName.trim();
+  if (!name) return '';
+
+  const lower = name.toLowerCase();
+  if (OG_META_PROPERTIES.has(lower)) {
+    return `meta[property="og:${lower}"]`;
+  }
+  if (lower === 'date') {
+    return 'meta[name="publication-date"]';
+  }
+
+  const kebab = name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+  return `meta[name="${kebab}"]`;
+}
+
+function createPropertyRow(propertiesContainer, {
+  propName = '',
+  propInfo = {},
+  focusName = false,
+} = {}) {
+  const property = document.querySelector('#index-property-row-template').content
+    .querySelector('.index-property')
+    .cloneNode(true);
+  const idSuffix = propName
+    ? toClassName(propName)
+    : Math.random().toString(36).substring(2, 12);
+  property.dataset.idSuffix = idSuffix;
+
+  const nameField = property.querySelector('#index-property-name');
+  const selectField = property.querySelector('#index-property-select');
+  const selectFirstField = property.querySelector('#index-property-select-first');
+  const valueTypeField = property.querySelector('#index-property-value-type');
+  const valueField = property.querySelector('#index-property-value');
+
+  nameField.id = `index-property-name-${idSuffix}`;
+  selectField.id = `index-property-select-${idSuffix}`;
+  selectFirstField.id = `index-property-select-first-${idSuffix}`;
+  valueTypeField.id = `index-property-value-type-${idSuffix}`;
+  valueField.id = `index-property-value-${idSuffix}`;
+
+  nameField.value = propName;
+  selectField.value = propInfo.select || '';
+  selectFirstField.value = propInfo.selectFirst || '';
+  if (propInfo.value !== undefined) {
+    valueTypeField.value = 'value';
+  } else if (propInfo.values !== undefined) {
+    valueTypeField.value = 'values';
+  } else {
+    valueTypeField.value = 'value';
+  }
+  const isNewRow = !propName
+    && propInfo.value === undefined
+    && propInfo.values === undefined;
+  valueField.value = propInfo.value
+    ?? propInfo.values?.join?.('\n')
+    ?? propInfo.values
+    ?? (isNewRow ? 'attribute(el, "content")' : '');
+
+  property.querySelector('label[for="index-property-name"]').htmlFor = nameField.id;
+  property.querySelector('label[for="index-property-select"]').htmlFor = selectField.id;
+  property.querySelector('label[for="index-property-select-first"]').htmlFor = selectFirstField.id;
+  property.querySelector('label[for="index-property-value-type"]').htmlFor = valueTypeField.id;
+  property.querySelector('label[for="index-property-value"]').htmlFor = valueField.id;
+
+  nameField.addEventListener('blur', () => {
+    const name = nameField.value.trim();
+    if (name) {
+      selectFirstField.value = metaSelectFirstForProperty(name);
+    }
+  });
+
+  property.querySelector('.remove-property-btn').addEventListener('click', () => {
+    property.remove();
+  });
+
+  propertiesContainer.appendChild(property);
+  if (focusName) {
+    nameField.focus({ preventScroll: true });
+    property.scrollIntoView({ block: 'nearest' });
+  }
+  return property;
+}
+
 function displayIndexDetails(indexName, indexDef, newIndex = false) {
   document.querySelector('dialog.index-details')?.remove();
 
   const fragment = document.querySelector('#index-details-dialog-template').content.cloneNode(true);
   const indexDetails = fragment.querySelector('dialog.index-details');
   document.body.append(fragment);
+
+  indexDetails.querySelector('.index-details-header h3').textContent = newIndex ? 'Add Index' : 'Edit Index';
+  indexDetails.querySelector('.index-dialog-org').textContent = org.value;
+  indexDetails.querySelector('.index-dialog-site').textContent = site.value;
 
   indexDetails.querySelector('#index-name').value = indexName;
   if (!newIndex) {
@@ -37,45 +127,9 @@ function displayIndexDetails(indexName, indexDef, newIndex = false) {
   indexDetails.querySelector('#index-exclude').value = indexDef?.exclude?.join('\n') || '';
 
   const propertiesContainer = indexDetails.querySelector('.properties-container');
+  const addPropertyRow = indexDetails.querySelector('.add-property-row');
   Object.entries(indexDef.properties).forEach(([propName, propInfo]) => {
-    propertiesContainer.append(document.querySelector('#index-property-row-template').content.cloneNode(true));
-    const property = propertiesContainer.lastElementChild;
-
-    const idSuffix = toClassName(propName);
-    property.dataset.idSuffix = idSuffix;
-    const nameField = property.querySelector('#index-property-name');
-    const selectField = property.querySelector('#index-property-select');
-    const selectFirstField = property.querySelector('#index-property-select-first');
-    const valueTypeField = property.querySelector('#index-property-value-type');
-    const valueField = property.querySelector('#index-property-value');
-
-    nameField.id = `index-property-name-${idSuffix}`;
-    selectField.id = `index-property-select-${idSuffix}`;
-    selectFirstField.id = `index-property-select-first-${idSuffix}`;
-    valueTypeField.id = `index-property-value-type-${idSuffix}`;
-    valueField.id = `index-property-value-${idSuffix}`;
-
-    nameField.value = propName;
-    selectField.value = propInfo.select || '';
-    selectFirstField.value = propInfo.selectFirst || '';
-    valueTypeField.value = propInfo.value !== undefined ? 'value' : 'values';
-    valueField.value = propInfo.value ?? propInfo.values?.join?.('\n') ?? propInfo.values ?? '';
-
-    const nameFieldLabel = property.querySelector('label[for="index-property-name"]');
-    const selectFieldLabel = property.querySelector('label[for="index-property-select"]');
-    const selectFirstFieldLabel = property.querySelector('label[for="index-property-select-first"]');
-    const valueTypeFieldLabel = property.querySelector('label[for="index-property-value-type"]');
-    const valueFieldLabel = property.querySelector('label[for="index-property-value"]');
-
-    nameFieldLabel.htmlFor = `index-property-name-${idSuffix}`;
-    selectFieldLabel.htmlFor = `index-property-select-${idSuffix}`;
-    selectFirstFieldLabel.htmlFor = `index-property-select-first-${idSuffix}`;
-    valueTypeFieldLabel.htmlFor = `index-property-value-type-${idSuffix}`;
-    valueFieldLabel.htmlFor = `index-property-value-${idSuffix}`;
-
-    property.querySelector('.remove-property-btn').addEventListener('click', () => {
-      property.remove();
-    });
+    createPropertyRow(propertiesContainer, { propName, propInfo });
   });
 
   indexDetails.showModal();
@@ -84,41 +138,9 @@ function displayIndexDetails(indexName, indexDef, newIndex = false) {
     indexDetails.remove();
   });
 
-  // Add event listeners for add/remove property buttons
-  const addPropertyBtn = indexDetails.querySelector('.add-property-btn');
+  const addPropertyBtn = addPropertyRow.querySelector('.add-property-btn');
   addPropertyBtn.addEventListener('click', () => {
-    propertiesContainer.append(document.querySelector('#index-property-row-template').content.cloneNode(true));
-    const property = propertiesContainer.lastElementChild;
-    const idSuffix = Math.random().toString(36).substring(2, 12);
-    property.dataset.idSuffix = idSuffix;
-
-    const nameField = property.querySelector('#index-property-name');
-    const selectField = property.querySelector('#index-property-select');
-    const selectFirstField = property.querySelector('#index-property-select-first');
-    const valueTypeField = property.querySelector('#index-property-value-type');
-    const valueField = property.querySelector('#index-property-value');
-
-    nameField.id = `index-property-name-${idSuffix}`;
-    selectField.id = `index-property-select-${idSuffix}`;
-    selectFirstField.id = `index-property-select-first-${idSuffix}`;
-    valueTypeField.id = `index-property-value-type-${idSuffix}`;
-    valueField.id = `index-property-value-${idSuffix}`;
-
-    const nameFieldLabel = property.querySelector('label[for="index-property-name"]');
-    const selectFieldLabel = property.querySelector('label[for="index-property-select"]');
-    const selectFirstFieldLabel = property.querySelector('label[for="index-property-select-first"]');
-    const valueTypeFieldLabel = property.querySelector('label[for="index-property-value-type"]');
-    const valueFieldLabel = property.querySelector('label[for="index-property-value"]');
-
-    nameFieldLabel.htmlFor = `index-property-name-${idSuffix}`;
-    selectFieldLabel.htmlFor = `index-property-select-${idSuffix}`;
-    selectFirstFieldLabel.htmlFor = `index-property-select-first-${idSuffix}`;
-    valueTypeFieldLabel.htmlFor = `index-property-value-type-${idSuffix}`;
-    valueFieldLabel.htmlFor = `index-property-value-${idSuffix}`;
-
-    property.querySelector('.remove-property-btn').addEventListener('click', () => {
-      property.remove();
-    });
+    createPropertyRow(propertiesContainer, { focusName: true });
   });
 
   const cancel = indexDetails.querySelector('#cancel-index');
@@ -187,13 +209,9 @@ function displayIndexDetails(indexName, indexDef, newIndex = false) {
     indexDetails.close();
   });
 
-  // close on click outside modal
+  // Close when clicking the dialog backdrop (not on keyboard-activated clicks)
   indexDetails.addEventListener('click', (e) => {
-    const {
-      left, right, top, bottom,
-    } = indexDetails.getBoundingClientRect();
-    const { clientX, clientY } = e;
-    if (clientX < left || clientX > right || clientY < top || clientY > bottom) {
+    if (e.target === indexDetails) {
       indexDetails.close();
     }
   });
@@ -215,13 +233,8 @@ function showJobStatus(jobDetails) {
     statusDialog.remove();
   });
 
-  // Close on click outside modal
   statusDialog.addEventListener('click', (e) => {
-    const {
-      left, right, top, bottom,
-    } = statusDialog.getBoundingClientRect();
-    const { clientX, clientY } = e;
-    if (clientX < left || clientX > right || clientY < top || clientY > bottom) {
+    if (e.target === statusDialog) {
       statusDialog.close();
       statusDialog.remove();
     }

--- a/tools/index-admin/index-admin.js
+++ b/tools/index-admin/index-admin.js
@@ -90,7 +90,7 @@ function createPropertyRow(propertiesContainer, {
 
   nameField.addEventListener('blur', () => {
     const name = nameField.value.trim();
-    if (name) {
+    if (name && !selectFirstField.value.trim()) {
       selectFirstField.value = metaSelectFirstForProperty(name);
     }
   });

--- a/tools/index-admin/index.html
+++ b/tools/index-admin/index.html
@@ -88,6 +88,10 @@
       <div class="index-details-content">
         <div class="index-details-header">
           <h3>Edit Index</h3>
+          <p class="index-dialog-context">
+            <span><strong>Organization:</strong> <span class="index-dialog-org"></span></span>
+            <span><strong>Site:</strong> <span class="index-dialog-site"></span></span>
+          </p>
         </div>
         <div class="index-details-body">
           <form>
@@ -110,7 +114,6 @@
             <div class="index-properties">
               <div class="properties-header-section">
                 <h4>Properties</h4>
-                <button type="button" class="button outline add-property-btn">Add Property</button>
               </div>
               <div class="properties-container">
                 <div class="properties-header">
@@ -121,6 +124,9 @@
                   <div class="header-cell">Value(s)</div>
                   <div class="header-cell"></div>
                 </div>
+              </div>
+              <div class="add-property-row">
+                <button type="button" class="button outline add-property-btn">Add Property</button>
               </div>
             </div>
             <div class="button-area">


### PR DESCRIPTION
After: https://feat-new-index-usability--helix-tools-website--adobe.aem.page/tools/index-admin/index.html

## Summary

Improves Index Admin add/edit: better property row workflow, dialog context (org/site), and fixes modal closing on keyboard activation.

## Changes
- Add Property row at bottom; focus name + scroll new row into view
- Defaults for new properties (Single, `attribute(el, "content")`); auto-fill Select First from name
- Dialog shows org/site; title is Add vs Edit Index
- Fix Space/Enter on buttons closing the dialog

## Test plan
- [ ] Add and edit index; verify org/site in header and save works
- [ ] Add property via click/Space; dialog stays open, row visible
- [ ] New row defaults and Select First on name blur