### PR TITLE
fix: use actual content source url for non-da editor link

### DIFF
--- a/widgets/bot-info/bot-info.js
+++ b/widgets/bot-info/bot-info.js
@@ -6,6 +6,7 @@ export default function decorate(widget) {
     const org = toClassName(params.get('org'));
     const site = toClassName(params.get('site'));
     const user = params.get('user');
+    const url = params.get('url');
 
     if (!user) {
       const userElement = document.querySelector('.bot-info-user');
@@ -19,7 +20,9 @@ export default function decorate(widget) {
     }
 
     const contentSource = document.querySelector('.bot-info-content-source');
-    const editUrl = `https://da.live/start?org=${org}&site=${site}`;
+    const editUrl = (!url || url.startsWith('https://content.da.live/'))
+      ? `https://da.live/start?org=${org}&site=${site}`
+      : new URL(url).origin;
 
     const editLink = document.createElement('a');
     editLink.target = '_blank';


### PR DESCRIPTION
## Summary

- The `bot-info` widget on the setup confirmation screen was hardcoding `https://da.live/start?org=…&site=…` as the editor link for all repos
- Now reads the `url` query param (the actual content source URL) and uses `new URL(url).origin` for non-DA repos (e.g. Xwalk/AEM Cloud), falling back to the DA editor link when the source is `content.da.live`
- DA setup flow is unchanged

## Related

Companion change in helix-bot that passes the correct content source URL: adobe/helix-bot#1981

## Test plan

- [x] DA site: `?url=https://content.da.live/org/site/` → editor link points to `da.live/start?org=…&site=…`
- [x] Xwalk site: `?url=https://author-pXXX-eYYY.adobeaemcloud.com/bin/franklin.delivery/…` → editor link points to `https://author-pXXX-eYYY.adobeaemcloud.com`
- Test on branch preview: `[https://fix-bot-info-xwalk-editor-url--helix-tools-website--adobe.aem.live/bot/setup?org=msagolj&site=kuckuck&url=https://author-p12345-e67890.adobeaemcloud.com/bin/franklin.delivery/msagolj/kuckuck/main](https://fix-bot-info-xwalk-editor-url--helix-tools-website--adobe.aem.live/bot/setup?org=msagolj&site=kuckuck&url=https://author-p12345-e67890.adobeaemcloud.com/bin/franklin.delivery/msagolj/kuckuck/main)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)