### PR TITLE
fix(site-query): hint to add tools.aem.live to trustedHosts on 403

### DIFF
--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -79,7 +79,6 @@ function updateTableError(table, errCode) {
       case 403:
         return {
           title: 'Forbidden',
-          msg: 'Unable to display results. Access to this content was denied. If the site is protected, you need to add <code>tools.aem.live</code> to the site\'s <code>sidekick.trustedHosts</code>. See <a href="https://www.aem.live/developer/sidekick-development" target="_blank" rel="noopener">here</a> for more information.',
           msg: 'Unable to display results. Access to this content was denied. If the site is protected, you need to add <code>tools.aem.live</code> to the site\'s <code>sidekick.trustedHosts</code>. See the <a href="https://www.aem.live/developer/sidekick-development" target="_blank" rel="noopener noreferrer">sidekick development docs</a> for more information.',
       case 404:
         return {

--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -80,6 +80,7 @@ function updateTableError(table, errCode) {
         return {
           title: 'Forbidden',
           msg: 'Unable to display results. Access to this content was denied. If the site is protected, you need to add <code>tools.aem.live</code> to the site\'s <code>sidekick.trustedHosts</code>. See the <a href="https://www.aem.live/developer/sidekick-development" target="_blank" rel="noopener noreferrer">sidekick development docs</a> for more information.',
+        };
       case 404:
         return {
           title: '404 Not Found Error',

--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -80,7 +80,7 @@ function updateTableError(table, errCode) {
         return {
           title: 'Forbidden',
           msg: 'Unable to display results. Access to this content was denied. If the site is protected, you need to add <code>tools.aem.live</code> to the site\'s <code>sidekick.trustedHosts</code>. See <a href="https://www.aem.live/developer/sidekick-development" target="_blank" rel="noopener">here</a> for more information.',
-        };
+          msg: 'Unable to display results. Access to this content was denied. If the site is protected, you need to add <code>tools.aem.live</code> to the site\'s <code>sidekick.trustedHosts</code>. See the <a href="https://www.aem.live/developer/sidekick-development" target="_blank" rel="noopener noreferrer">sidekick development docs</a> for more information.',
       case 404:
         return {
           title: '404 Not Found Error',

--- a/tools/site-query/scripts.js
+++ b/tools/site-query/scripts.js
@@ -79,7 +79,7 @@ function updateTableError(table, errCode) {
       case 403:
         return {
           title: 'Forbidden',
-          msg: 'Unable to display results. Access to this content was denied.',
+          msg: 'Unable to display results. Access to this content was denied. If the site is protected, you need to add <code>tools.aem.live</code> to the site\'s <code>sidekick.trustedHosts</code>. See <a href="https://www.aem.live/developer/sidekick-development" target="_blank" rel="noopener">here</a> for more information.',
         };
       case 404:
         return {


### PR DESCRIPTION
When the site-query tool receives a 403 from a protected site, the Forbidden error now hints that `tools.aem.live` needs to be added to the site's `sidekick.trustedHosts`, linking to the sidekick development docs.

Preview: https://trusted-hosts-hint--helix-tools-website--adobe.aem.page/tools/site-query/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)