### PR TITLE
feat(ai-optel-report): JS errors business impact analysis

### DIFF
--- a/blocks/ai-optel-report-generator/core/analysis-engine.js
+++ b/blocks/ai-optel-report-generator/core/analysis-engine.js
@@ -5,6 +5,7 @@ import {
   extractFacetsFromExplorer,
   initializeDynamicFacets,
   handleDynamicFacetToolCall,
+  crossReferenceErrors,
 } from './facet-manager.js';
 import {
   processMetricsBatches,
@@ -42,7 +43,114 @@ async function getOverviewAnalysisTemplate() {
   return overviewAnalysisTemplateCache || 'CREATE A CLEAN, PROFESSIONAL REPORT WITH STRUCTURED SECTIONS.';
 }
 
-function buildFinalSynthesisMessage(dashboardData, allInsights) {
+function getCwvSeverityLabel(classes) {
+  if (classes.includes('score-poor')) return ' [POOR]';
+  if (classes.includes('score-ni')) return ' [NEEDS IMPROVEMENT]';
+  return '';
+}
+
+function formatCwvMetrics(metrics) {
+  if (!metrics) return '';
+  const parts = Object.entries(metrics).map(([metric, data]) => {
+    const severity = getCwvSeverityLabel(data.classes);
+    const interesting = data.classes.includes('interesting') ? ' *statistically significant*' : '';
+    return `${metric}: ${data.value}${severity}${interesting}`;
+  });
+  return parts.length > 0 ? ` | CWV: ${parts.join(', ')}` : '';
+}
+
+function formatErrorCrossReference(crossRefData) {
+  if (!crossRefData) return '';
+
+  const sections = [];
+
+  if (crossRefData.url) {
+    const pages = crossRefData.url
+      .map((item) => `  - ${item.text}: ${item.count.toLocaleString()} errors`)
+      .join('\n');
+    sections.push(`Pages with JS errors (filtered by checkpoint=error):\n${pages}`);
+  }
+
+  if (crossRefData.userAgent) {
+    const devices = crossRefData.userAgent
+      .map((item) => `  - ${item.text}: ${item.count.toLocaleString()} errors`)
+      .join('\n');
+    sections.push(`Devices/browsers with JS errors (filtered by checkpoint=error):\n${devices}`);
+  }
+
+  if (crossRefData['error.source']) {
+    const sources = crossRefData['error.source']
+      .map((item) => `  - ${item.text}: ${item.count.toLocaleString()} errors${formatCwvMetrics(item.metrics)}`)
+      .join('\n');
+    sections.push(`Error sources with CWV impact (global, filtered by checkpoint=error):\n${sources}`);
+  }
+
+  if (crossRefData['error.target']) {
+    const targets = crossRefData['error.target']
+      .map((item) => `  - ${item.text}: ${item.count.toLocaleString()} errors${formatCwvMetrics(item.metrics)}`)
+      .join('\n');
+    sections.push(`Error targets with CWV impact (global, filtered by checkpoint=error):\n${targets}`);
+  }
+
+  if (crossRefData.perPageErrors) {
+    const perPage = crossRefData.perPageErrors.map((entry) => {
+      const lines = [`  Page: ${entry.page} (${entry.errorCount.toLocaleString()} total errors)`];
+      if (entry['error.source']) {
+        lines.push('    Error sources on this page:');
+        entry['error.source'].forEach((item) => {
+          lines.push(`      - ${item.text}: ${item.count.toLocaleString()}${formatCwvMetrics(item.metrics)}`);
+        });
+      }
+      if (entry['error.target']) {
+        lines.push('    Error targets on this page:');
+        entry['error.target'].forEach((item) => {
+          lines.push(`      - ${item.text}: ${item.count.toLocaleString()}${formatCwvMetrics(item.metrics)}`);
+        });
+      }
+      return lines.join('\n');
+    }).join('\n\n');
+    sections.push(`PER-PAGE ERROR BREAKDOWN (checkpoint=error + url filter applied):\n${perPage}`);
+  }
+
+  if (sections.length === 0) return '';
+
+  const totalLine = crossRefData.totalErrorCount
+    ? `TOTAL ERROR COUNT (from checkpoint=error): ${crossRefData.totalErrorCount.toLocaleString()} (raw: ${crossRefData.totalErrorCountRaw})\nUSE THIS EXACT NUMBER when linking to checkpoint=error. Do NOT sum sub-categories or use any other value.\n`
+    : '';
+
+  return `\nERROR CROSS-REFERENCE DATA (errors filtered by page and device):
+${totalLine}
+${sections.join('\n\n')}
+
+Use this data for the Business Impact Analysis section. ONLY cite findings that appear in this cross-reference data:
+- Pages listed above with error counts = proven errors on those pages (cite the count shown)
+- Per-page breakdowns = proven error types ON specific pages (this is the strongest evidence)
+- Devices listed above = proven device-specific error concentration
+- Global error.source/error.target = overall error type distribution
+- CWV data marked [POOR] = errors correlated with failing Core Web Vitals (prioritize these!)
+- CWV data marked *statistically significant* = performance deviation is not random, it's proven
+- If a page is NOT in this list, do NOT claim it has errors
+- If an error type is NOT shown in a page's breakdown, do NOT claim that error type occurs on that page
+
+PRIORITIZATION using CWV signals:
+- Errors with [POOR] CWV that are also *statistically significant* = CRITICAL (proven performance-degrading errors)
+- Errors with [POOR] CWV = HIGH (correlated with bad performance, worth investigating)
+- Errors with [NEEDS IMPROVEMENT] CWV = MODERATE
+- Errors without CWV data or with passing CWV = prioritize by volume and page criticality only
+
+IMPORTANT: Every data point MUST be wrapped in a facet link span.
+- Page references: <span data-facet="url" data-facet-value="PAGE_PATH">page name (COUNT errors)</span>
+- Error sources (global): <span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.source" data-nested-value="SOURCE">error description</span>
+- Error targets (global): <span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.target" data-nested-value="TARGET">error message</span>
+- Error on a specific page (from per-page breakdown): add data-url-context to enable BOTH error + URL checkboxes:
+  <span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.source" data-nested-value="SOURCE" data-url-context="PAGE_PATH">error on page</span>
+  This filters dashboard to checkpoint=error + error.source=SOURCE + url=PAGE_PATH in one click.
+- Device segments: <span data-facet="userAgent" data-facet-value="VALUE">device description</span>
+No unlinked data — every mentioned metric must be clickable for validation.
+No speculation — only state what the data above explicitly shows.\n`;
+}
+
+function buildFinalSynthesisMessage(dashboardData, allInsights, crossRefData) {
   const hasMetrics = Object.keys(dashboardData.metrics).length > 0;
 
   return `Create a polished, professional analysis report. Use only the data below as source material.
@@ -69,7 +177,7 @@ ${(() => {
     const perInsight = Math.min(600, Math.floor(maxTotal / allInsights.length));
     return allInsights.map((insight) => insight.slice(0, perInsight)).join('\n---\n');
   })()}
-
+${formatErrorCrossReference(crossRefData)}
 Generate the report following the template structure in your system instructions.`;
 }
 
@@ -104,6 +212,13 @@ async function callAnthropicAPI(dashboardData, facetTools, progressCallback) {
     if (allInsights.length > 0) {
       if (progressCallback) {
         progressCallback(2, 'completed', 'Metrics batch processing completed');
+        progressCallback(3, 'in-progress', 'Cross-referencing errors with pages and devices...', 5);
+      }
+
+      // Cross-reference errors with URLs and user agents for business impact analysis
+      const crossRefData = await crossReferenceErrors();
+
+      if (progressCallback) {
         progressCallback(3, 'in-progress', 'Generating streamlined overview report...', 10);
       }
 
@@ -119,6 +234,7 @@ async function callAnthropicAPI(dashboardData, facetTools, progressCallback) {
       const finalSynthesisMessage = buildFinalSynthesisMessage(
         dashboardData,
         allInsights,
+        crossRefData,
       );
 
       const maxTokens = API_CONFIG.SYNTHESIS_MAX_TOKENS || 4096;

--- a/blocks/ai-optel-report-generator/core/facet-manager.js
+++ b/blocks/ai-optel-report-generator/core/facet-manager.js
@@ -286,69 +286,72 @@ export async function crossReferenceErrors() {
 
   const results = { totalErrorCount, totalErrorCountRaw: errorCountTitle.split(' ')[0] };
 
-  // Read top-level facets (url, userAgent) while filtered to errors
-  ['url', 'userAgent'].forEach((facetName) => {
-    const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
-    if (!facetEl) return;
-    const items = extractLabelData(facetEl, false);
-    if (items.length > 0) {
-      results[facetName] = items.slice(0, 15);
+  try {
+    // Read top-level facets (url, userAgent) while filtered to errors
+    ['url', 'userAgent'].forEach((facetName) => {
+      const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
+      if (!facetEl) return;
+      const items = extractLabelData(facetEl, false);
+      if (items.length > 0) {
+        results[facetName] = items.slice(0, 15);
+      }
+    });
+
+    // Read nested error facets (error.source, error.target) with CWV metrics
+    ['error.source', 'error.target'].forEach((facetName) => {
+      const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
+      if (!facetEl) return;
+      const items = extractLabelData(facetEl, true);
+      if (items.length > 0) {
+        results[facetName] = items.slice(0, 10);
+      }
+    });
+
+    // Drill into top error-affected pages to get per-page error breakdowns
+    const urlFacetEl = sidebar.querySelector('[facet="url"]');
+    if (urlFacetEl && results.url && results.url.length > 0) {
+      const topPages = results.url.slice(0, 5);
+
+      const perPageErrors = await topPages.reduce(async (accPromise, page) => {
+        const acc = await accPromise;
+        const urlInput = urlFacetEl.querySelector(`input[value="${CSS.escape(page.text)}"]`);
+        if (!urlInput) return acc;
+
+        urlInput.click();
+        await new Promise((r) => { setTimeout(r, 1200); });
+
+        const pageBreakdown = { page: page.text, errorCount: page.count };
+
+        ['error.source', 'error.target'].forEach((facetName) => {
+          const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
+          if (!facetEl) return;
+          const items = extractLabelData(facetEl, true);
+          if (items.length > 0) {
+            pageBreakdown[facetName] = items.slice(0, 5);
+          }
+        });
+
+        acc.push(pageBreakdown);
+
+        urlInput.click();
+        await new Promise((r) => { setTimeout(r, 1200); });
+
+        return acc;
+      }, Promise.resolve([]));
+
+      if (perPageErrors.length > 0) {
+        results.perPageErrors = perPageErrors;
+      }
     }
-  });
-
-  // Read nested error facets (error.source, error.target) with CWV metrics
-  ['error.source', 'error.target'].forEach((facetName) => {
-    const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
-    if (!facetEl) return;
-    const items = extractLabelData(facetEl, true);
-    if (items.length > 0) {
-      results[facetName] = items.slice(0, 10);
-    }
-  });
-
-  // Drill into top error-affected pages to get per-page error breakdowns
-  const urlFacetEl = sidebar.querySelector('[facet="url"]');
-  if (urlFacetEl && results.url && results.url.length > 0) {
-    const topPages = results.url.slice(0, 5);
-
-    const perPageErrors = await topPages.reduce(async (accPromise, page) => {
-      const acc = await accPromise;
-      const urlInput = urlFacetEl.querySelector(`input[value="${CSS.escape(page.text)}"]`);
-      if (!urlInput) return acc;
-
-      urlInput.click();
-      await new Promise((r) => { setTimeout(r, 1200); });
-
-      const pageBreakdown = { page: page.text, errorCount: page.count };
-
-      ['error.source', 'error.target'].forEach((facetName) => {
-        const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
-        if (!facetEl) return;
-        const items = extractLabelData(facetEl, true);
-        if (items.length > 0) {
-          pageBreakdown[facetName] = items.slice(0, 5);
-        }
-      });
-
-      acc.push(pageBreakdown);
-
-      urlInput.click();
-      await new Promise((r) => { setTimeout(r, 1200); });
-
-      return acc;
-    }, Promise.resolve([]));
-
-    if (perPageErrors.length > 0) {
-      results.perPageErrors = perPageErrors;
+  } finally {
+    if (!wasChecked && errorInput.checked) {
+      errorInput.click();
+      await new Promise((r) => { setTimeout(r, 1500); });
     }
   }
 
-  // Restore original checkpoint state
-  if (!wasChecked) {
-    errorInput.click();
-    await new Promise((r) => { setTimeout(r, 1500); });
-  }
-
-  if (Object.keys(results).length === 0) return null;
+  const hasFacetData = results.url || results.userAgent
+    || results['error.source'] || results['error.target'] || results.perPageErrors;
+  if (!hasFacetData) return null;
   return results;
 }

--- a/blocks/ai-optel-report-generator/core/facet-manager.js
+++ b/blocks/ai-optel-report-generator/core/facet-manager.js
@@ -168,7 +168,21 @@ export async function handleDynamicFacetToolCall(toolName, input, useQueue = tru
         }
 
         case 'analyze': {
-          const items = extractLabelData(facetEl, true);
+          const items = extractLabelData(facetEl, true).map((item) => {
+            if (!item.metrics) return item;
+            const enriched = { ...item, metrics: {} };
+            Object.entries(item.metrics).forEach(([metric, data]) => {
+              let status = 'good';
+              if (data.classes.includes('score-poor')) status = 'poor';
+              else if (data.classes.includes('score-ni')) status = 'needs-improvement';
+              enriched.metrics[metric] = {
+                value: data.value,
+                status,
+                significant: data.classes.includes('interesting'),
+              };
+            });
+            return enriched;
+          });
           return {
             success: true,
             facetName,
@@ -240,4 +254,101 @@ export function initializeDynamicFacets() {
 /** Reset cached facet tools */
 export function resetCachedFacetTools() {
   cachedFacetTools = null;
+}
+
+/**
+ * Cross-reference errors with URLs, user agents, and nested error facets
+ * by applying checkpoint=error filter and reading which pages/devices show errors,
+ * plus error.source and error.target breakdowns globally and per top page.
+ * Returns structured data for the business-impact analysis.
+ */
+export async function crossReferenceErrors() {
+  const sidebar = document.querySelector('facet-sidebar');
+  if (!sidebar) return null;
+
+  const checkpointEl = sidebar.querySelector('[facet="checkpoint"]');
+  if (!checkpointEl) return null;
+
+  const errorInput = checkpointEl.querySelector('input[value="error"]');
+  if (!errorInput) return null;
+
+  // Read the total error count from the checkbox label before filtering
+  const errorLabel = checkpointEl.querySelector('label[for*="error"]');
+  const errorCountEl = errorLabel?.querySelector('number-format');
+  const errorCountTitle = errorCountEl?.getAttribute('title') || '0';
+  const totalErrorCount = parseInt(errorCountTitle.split(' ')[0].replace(/\D/g, ''), 10) || 0;
+
+  const wasChecked = errorInput.checked;
+  if (!wasChecked) {
+    errorInput.click();
+    await new Promise((r) => { setTimeout(r, 1500); });
+  }
+
+  const results = { totalErrorCount, totalErrorCountRaw: errorCountTitle.split(' ')[0] };
+
+  // Read top-level facets (url, userAgent) while filtered to errors
+  ['url', 'userAgent'].forEach((facetName) => {
+    const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
+    if (!facetEl) return;
+    const items = extractLabelData(facetEl, false);
+    if (items.length > 0) {
+      results[facetName] = items.slice(0, 15);
+    }
+  });
+
+  // Read nested error facets (error.source, error.target) with CWV metrics
+  ['error.source', 'error.target'].forEach((facetName) => {
+    const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
+    if (!facetEl) return;
+    const items = extractLabelData(facetEl, true);
+    if (items.length > 0) {
+      results[facetName] = items.slice(0, 10);
+    }
+  });
+
+  // Drill into top error-affected pages to get per-page error breakdowns
+  const urlFacetEl = sidebar.querySelector('[facet="url"]');
+  if (urlFacetEl && results.url && results.url.length > 0) {
+    const topPages = results.url.slice(0, 5);
+
+    const perPageErrors = await topPages.reduce(async (accPromise, page) => {
+      const acc = await accPromise;
+      const urlInput = urlFacetEl.querySelector(`input[value="${CSS.escape(page.text)}"]`);
+      if (!urlInput) return acc;
+
+      urlInput.click();
+      await new Promise((r) => { setTimeout(r, 1200); });
+
+      const pageBreakdown = { page: page.text, errorCount: page.count };
+
+      ['error.source', 'error.target'].forEach((facetName) => {
+        const facetEl = sidebar.querySelector(`[facet="${facetName}"]`);
+        if (!facetEl) return;
+        const items = extractLabelData(facetEl, true);
+        if (items.length > 0) {
+          pageBreakdown[facetName] = items.slice(0, 5);
+        }
+      });
+
+      acc.push(pageBreakdown);
+
+      urlInput.click();
+      await new Promise((r) => { setTimeout(r, 1200); });
+
+      return acc;
+    }, Promise.resolve([]));
+
+    if (perPageErrors.length > 0) {
+      results.perPageErrors = perPageErrors;
+    }
+  }
+
+  // Restore original checkpoint state
+  if (!wasChecked) {
+    errorInput.click();
+    await new Promise((r) => { setTimeout(r, 1500); });
+  }
+
+  if (Object.keys(results).length === 0) return null;
+  return results;
 }

--- a/blocks/ai-optel-report-generator/reports/facet-link-generator.js
+++ b/blocks/ai-optel-report-generator/reports/facet-link-generator.js
@@ -65,75 +65,17 @@ export function buildFacetInfoSection(dashboardData) {
   ];
 
   sections.push(
-    '\nCORRECT USAGE EXAMPLES:',
-    '',
-    'IMPORTANT: Include relevant metrics/numbers INSIDE the data-facet span so they become part of the clickable link!',
-    'Use <number-format> tags with proper attributes for all numbers (see Number Formatting section).',
-    '',
-    '1. SIMPLE LINK (Main facet only - Checkpoint):',
-    '<p>• <span data-facet="checkpoint" data-facet-value="lcp">LCP events show <number-format title="2.3s ±0.4s" sample-size="1234"><span class="formatted-value">2.3s</span></number-format> average load time</span>.</p>',
-    'URL: ?checkpoint=lcp',
-    '',
-    '2. SIMPLE LINK (Main facet only - URL):',
-    '<p>• <span data-facet="url" data-facet-value="/checkout">The /checkout page has <number-format title="65% ±5%" sample-size="450"><span class="formatted-value">65%</span></number-format> bounce rate</span>.</p>',
-    'URL: ?url=/checkout',
-    '',
-    '3. SIMPLE LINK (Main facet only - UserAgent):',
-    'Tool returns: {"text": "All Mobile", "value": "mobile", "count": 8100}',
-    'CORRECT: <span data-facet="userAgent" data-facet-value="mobile">Mobile users have <number-format sample-size="8100"><span class="formatted-value">8.1k</span></number-format> page views</span>',
-    'WRONG: <span data-facet-value="All Mobile">... (uses "text" field - will NOT work)',
-    'ALWAYS use the "value" field from tool response, NEVER use "text" or "label"',
-    '',
-    '4. NESTED LINK (One nested facet - error.source):',
-    '<p>• <span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.source" data-nested-value="network">Network errors affect <number-format sample-size="456"><span class="formatted-value">456</span></number-format> users</span>.</p>',
-    'URL: ?checkpoint=error&error.source=network',
-    '',
-    '5. NESTED LINK (One nested facet - error.target directly, without source):',
-    '<p>• <span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.target" data-nested-value="TypeError: Cannot read property">This TypeError affects <number-format sample-size="89"><span class="formatted-value">89</span></number-format> users</span>.</p>',
-    'URL: ?checkpoint=error&error.target=TypeError: Cannot read property',
-    'You can link directly to error.target WITHOUT specifying error.source!',
-    '',
-    '6. NESTED LINK (Two nested facets - both source and target):',
-    '<p>• <span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.source" data-nested-value="network" data-nested-facet-2="error.target" data-nested-value-2="TypeError: Cannot read property">This specific TypeError from network: <number-format sample-size="45"><span class="formatted-value">45</span></number-format></span>.</p>',
-    'URL: ?checkpoint=error&error.source=network&error.target=TypeError: Cannot read property',
-    '',
-    '7. NESTED LINK (Click target URL - EXACT URL from tool required):',
-    'Tool returns: {"facet": "click.target", "value": "https://example.com/watch-collection.html", "count": 123}',
-    'CORRECT: <span data-facet="checkpoint" data-facet-value="click" data-nested-facet="click.target" data-nested-value="https://example.com/watch-collection.html">Watch collection clicks</span>',
-    'WRONG: data-nested-value="https://example.com/watches.html" (different URL - will NOT work!)',
-    'For nested facets with URLs: Use the EXACT full URL from tool response',
-    '',
-    'WHEN TO USE NESTED FACETS:',
-    '  • Use one nested facet when you have data for that specific dimension',
-    '  • Use two nested facets when you have data for both and want precise filtering',
-    '  • You can use .target WITHOUT .source - they are independent filters!',
-    '  ONLY create nested links if you called a tool for that nested facet!',
-  );
-
-  sections.push(
-    '\nINVALID EXAMPLES (will NOT work):',
-    '• <span data-facet="browser">Chrome</span> - Wrong facet! Use "userAgent" not "browser"',
-    '• <span data-facet="device">mobile</span> - Wrong facet! Use "userAgent" not "device"',
-    '• <span data-nested-facet="error.source" data-nested-value="network">...</span> - Missing parent checkpoint!',
-    '• <span data-facet="url" data-facet-value="/checkout">The page</span> has 3.2s LCP - Metric outside span!',
-    '',
-    'CRITICAL RULES:',
+    '\nRULES:',
     '  1. MAIN FACET REQUIRED: Every link needs data-facet and data-facet-value',
-    '  2. NESTED FACETS ARE OPTIONAL: Add them when you have specific drill-down data',
-    '  3. NESTED FACETS ARE INDEPENDENT: You can use .source, .target, or both',
-    '  4. ONLY create links for values AND facet names you see in TOOL RESPONSES',
-    '     DO NOT invent nested facet names - verify from "NESTED FACETS" list above',
-    '  5. ALWAYS use the EXACT "value" field from tool response, NEVER "text" or "label"',
-    '     Tool returns: {"text": "All Mobile", "value": "mobile", "count": 8100}',
-    '     USE: data-facet-value="mobile"',
-    '     NEVER: data-facet-value="All Mobile"',
-    '  6. Use EXACT value format from tool - DO NOT paraphrase, shorten, or modify',
-    '  7. SYNTAX REFERENCE:',
-    '     Simple: <span data-facet="NAME" data-facet-value="VALUE">text</span>',
+    '  2. NESTED FACETS ARE INDEPENDENT: .source and .target can be used alone or together',
+    '  3. ONLY use facet names and values from TOOL RESPONSES — never invent them',
+    '  4. ALWAYS use the "value" field from tool response, NEVER "text" or "label"',
+    '  5. Include metrics/numbers INSIDE the span so they become part of the clickable link',
+    '  6. SYNTAX:',
+    '     Simple: <span data-facet="NAME" data-facet-value="VALUE">text with numbers</span>',
     '     One nested: + data-nested-facet="NAME" data-nested-value="VALUE"',
     '     Two nested: + data-nested-facet-2="NAME" data-nested-value-2="VALUE"',
-    '  8. INCLUDE METRICS INSIDE SPANS: Put numbers inside data-facet span to make them clickable',
-    '  9. All links automatically PRESERVE existing url and userAgent filters',
+    '     URL context: + data-url-context="/page-path" (enables error + URL checkboxes together)',
     '',
     '==== END FACET INFO ====\n',
   );
@@ -167,7 +109,7 @@ function normalizeUrl(url) {
 /** Generate dashboard URL with facet params (preserves existing url/userAgent filters) */
 function generateFacetLink(facetName, facetValue, options = {}) {
   const {
-    nestedFacet, nestedValue, nestedFacet2, nestedValue2,
+    nestedFacet, nestedValue, nestedFacet2, nestedValue2, urlContext,
   } = options;
   const currentParams = new URL(window.location.href).searchParams;
   const params = new URLSearchParams();
@@ -200,6 +142,10 @@ function generateFacetLink(facetName, facetValue, options = {}) {
     if (nestedFacet2 && nestedValue2) {
       addParam(nestedFacet2, nestedValue2);
     }
+  }
+
+  if (urlContext) {
+    addParam('url', urlContext);
   }
 
   const { pathname } = window.location;
@@ -328,13 +274,17 @@ export function convertSpansToLinks(htmlContent) {
       return;
     }
 
+    const urlContext = el.getAttribute('data-url-context');
+
     const cv = correctValue(facetName, facetValue);
     const cn = nestedFacet ? correctValue(nestedFacet, nestedValue) : null;
     const cn2 = nestedFacet2 ? correctValue(nestedFacet2, nestedValue2) : null;
+    const cu = urlContext ? normalizeUrl(urlContext) : null;
 
     const allValid = isValidFacetValue(facetName, cv)
       && (!nestedFacet || isValidFacetValue(nestedFacet, cn))
-      && (!nestedFacet2 || isValidFacetValue(nestedFacet2, cn2));
+      && (!nestedFacet2 || isValidFacetValue(nestedFacet2, cn2))
+      && (!cu || isValidFacetValue('url', cu));
 
     if (!allValid) {
       stats.skippedNonExistent.push(`${facetName}="${facetValue}"`);
@@ -344,10 +294,11 @@ export function convertSpansToLinks(htmlContent) {
     let title = `View ${facetName}: ${cv}`;
     if (nestedFacet) title += ` + ${nestedFacet}: ${cn}`;
     if (nestedFacet2) title += ` + ${nestedFacet2}: ${cn2}`;
+    if (cu) title += ` on ${cu}`;
 
     const anchor = Object.assign(doc.createElement('a'), {
       href: generateFacetLink(facetName, cv, {
-        nestedFacet, nestedValue: cn, nestedFacet2, nestedValue2: cn2,
+        nestedFacet, nestedValue: cn, nestedFacet2, nestedValue2: cn2, urlContext: cu,
       }),
       className: 'facet-link',
       innerHTML: el.innerHTML,

--- a/blocks/ai-optel-report-generator/reports/report-viewer.css
+++ b/blocks/ai-optel-report-generator/reports/report-viewer.css
@@ -135,6 +135,8 @@ facet-sidebar.report-view-active > form {
   border-radius: 3px;
 }
 
+/* Business Impact expandable section */
+
 /* Number formatting */
 .report-sections .content-item .num {
   font-family: 'SF Mono', monaco, consolas, 'Courier New', monospace;

--- a/blocks/ai-optel-report-generator/reports/report-viewer.css
+++ b/blocks/ai-optel-report-generator/reports/report-viewer.css
@@ -135,8 +135,6 @@ facet-sidebar.report-view-active > form {
   border-radius: 3px;
 }
 
-/* Business Impact expandable section */
-
 /* Number formatting */
 .report-sections .content-item .num {
   font-family: 'SF Mono', monaco, consolas, 'Courier New', monospace;

--- a/blocks/ai-optel-report-generator/templates/overview-analysis-template.html
+++ b/blocks/ai-optel-report-generator/templates/overview-analysis-template.html
@@ -157,7 +157,7 @@
   <p><b>SECTION STRUCTURE — business impact first, then user impact:</b></p>
   <ol>
     <li><b>Open with top pages affected by errors.</b> Use the PER-PAGE ERROR BREAKDOWN from cross-reference data. Lead with the pages that have the most errors, especially conversion-critical ones (checkout, cart, payment, signup, upload) or high-traffic pages. For each page: name it (linked), state its error count, and list the specific error types occurring ON that page (linked with nested facets). Include CWV impact if the per-page data shows poor+significant metrics.</li>
-    <li><b>Then cover the broader error patterns</b> in flowing narrative: total error rate, dominant error sources/targets globally. Use 2-3 bullets for the top error types. <b>Every bullet MUST be wrapped in a facet link</b> — error sources use <code>data-nested-facet="error.source"</code>, error targets use <code>data-nested-facet="error.target"</code>. No plain-text mentions of error sources or targets without a link.</li>
+    <li><b>Then cover the broader error patterns</b> in flowing narrative: total error rate, dominant error sources/targets globally. List each significant error type as a bullet — however many the data shows (do NOT pre-state a count like "two patterns" or "three sources" before the list). <b>Every bullet MUST be wrapped in a facet link</b> — error sources use <code>data-nested-facet="error.source"</code>, error targets use <code>data-nested-facet="error.target"</code>. No plain-text mentions of error sources or targets without a link.</li>
     <li><b>Close with user-facing consequence</b> — what real users experience because of these errors (broken forms, failed uploads, unresponsive pages). Connect each consequence to the specific page + error data that proves it. Every consequence statement must include a linked reference.</li>
   </ol>
 
@@ -171,7 +171,9 @@
     <li>The UX consequence paragraph MUST also be linked — if you say "users experience broken navigation", link to the specific error type and page where it happens. Every consequence claim needs a data-facet span pointing to the proof</li>
   </ul>
 
-  <p><b>STYLE:</b> Natural flowing paragraphs with 2-3 bullets where listing specifics. Every data point linked. Don't open with the dry error rate percentage — open with the pages where errors hit hardest. If you state a count ("dominated by two patterns"), the number of items that follow MUST match exactly — don't say "two" then list three.</p>
+  <p><b>COUNT-MATCH RULE:</b> If you state a number of items ("dominated by two patterns", "three key sources"), the items listed MUST match that number EXACTLY. Don't say "two" then list three or four. Count your bullets BEFORE writing the intro sentence.</p>
+
+  <p><b>STYLE:</b> Natural flowing paragraphs with bullets where listing specifics. Every data point linked. Don't open with the dry error rate percentage — open with the pages where errors hit hardest. NEVER pre-state a count before a list (no "dominated by two patterns", "three key sources"). Just list the items directly.</p>
 
   <p><b>ERROR COUNT ACCURACY:</b></p>
   <ul>

--- a/blocks/ai-optel-report-generator/templates/overview-analysis-template.html
+++ b/blocks/ai-optel-report-generator/templates/overview-analysis-template.html
@@ -42,6 +42,7 @@
   <p><b>EDGE DELIVERY SERVICES (EDS) SITE DETECTION:</b></p>
   <ul>
     <li><b>If tool responses include <code>checkpoint=viewblock</code>, this is an Edge Delivery Services site</b></li>
+    <li><b>NEVER mention detection logic in the report.</b> Do not say "viewblock checkpoints detected", "based on viewblock data", or explain how you identified the site as EDS. This is internal logic — the report reader already knows their site platform</li>
     <li>EDS sites have built-in automatic optimizations - tailor recommendations accordingly</li>
     <li><b>DO NOT recommend for EDS sites:</b>
       <ul>
@@ -124,7 +125,7 @@
   <ul>
     <li>Include date range context from DATA TIME PERIOD section</li>
     <li>"Rising"/"falling" = trends, not absolute performance - focus on actual values vs thresholds</li>
-    <li><b>CSS classes = severity:</b> <code>score-poor</code> = CRITICAL (failing CWV, MUST highlight), <code>score-ni</code> = needs improvement, <code>score-good</code> = passing</li>
+    <li><b>CWV status in tool responses:</b> <code>"status": "poor"</code> = CRITICAL (failing CWV, MUST highlight), <code>"status": "needs-improvement"</code> = needs improvement, <code>"status": "good"</code> = passing. <code>"significant": true</code> = statistically significant deviation (proven, not random noise — prioritize these)</li>
     <li><b>Business thresholds:</b> Engagement/conversion &lt;25% = CRITICAL, bounce &gt;60% = CRITICAL</li>
     <li>Analyze ALL facets - not just performance. Check facet title attributes for context</li>
     <li>UTM data captures parameter names only (privacy by design) - don't suggest capturing values</li>
@@ -142,7 +143,7 @@
 
   <p><b>CONDITIONAL SECTIONS:</b></p>
   <ul>
-    <li><b>JavaScript Errors:</b> Only include if errors ≥1% of total traffic (calculate: error count / page views × 100). Skip entirely if below threshold.</li>
+    <li><b>JavaScript Errors:</b> Always include if errors ≥1% of total traffic (calculate: error count / page views × 100). Also include if errors are below 1% BUT concentrated on conversion-critical pages (checkout, cart, payment, contact, signup, login) or affecting a specific device/locale segment entirely — low volume does not mean low impact.</li>
     <li><b>All Other Sections:</b> Always include (Executive Summary, Performance Impact, User Engagement, Traffic & Acquisition, Content Effectiveness, Conversion Funnel, Geographic Insights, Market Opportunities, Business Impact, Priority Actions)</li>
   </ul>
 
@@ -151,39 +152,118 @@
   <pre>&lt;p&gt;• &lt;span data-facet="checkpoint" data-facet-value="cwv-lcp"&gt;LCP at 3.2s exceeds 2.5s threshold—mobile bounce 65% vs desktop 32%.&lt;/span&gt;&lt;/p&gt;</pre>
 
   <h4>JAVASCRIPT ERRORS THAT NEED ATTENTION</h4>
-  <p><b>Only if errors ≥1% of traffic.</b> Calculate: (error count / page views) × 100</p>
+  <p><b>Include if errors ≥1% of traffic OR if errors concentrate on business-critical pages/segments.</b> Calculate overall rate: (error count / page views) × 100</p>
+
+  <p><b>SECTION STRUCTURE — business impact first, then user impact:</b></p>
+  <ol>
+    <li><b>Open with top pages affected by errors.</b> Use the PER-PAGE ERROR BREAKDOWN from cross-reference data. Lead with the pages that have the most errors, especially conversion-critical ones (checkout, cart, payment, signup, upload) or high-traffic pages. For each page: name it (linked), state its error count, and list the specific error types occurring ON that page (linked with nested facets). Include CWV impact if the per-page data shows poor+significant metrics.</li>
+    <li><b>Then cover the broader error patterns</b> in flowing narrative: total error rate, dominant error sources/targets globally. Use 2-3 bullets for the top error types. <b>Every bullet MUST be wrapped in a facet link</b> — error sources use <code>data-nested-facet="error.source"</code>, error targets use <code>data-nested-facet="error.target"</code>. No plain-text mentions of error sources or targets without a link.</li>
+    <li><b>Close with user-facing consequence</b> — what real users experience because of these errors (broken forms, failed uploads, unresponsive pages). Connect each consequence to the specific page + error data that proves it. Every consequence statement must include a linked reference.</li>
+  </ol>
+
+  <p><b>DATA-BACKED FINDINGS ONLY:</b></p>
+  <ul>
+    <li>Every finding MUST trace to a specific tool response or cross-reference result</li>
+    <li>DO NOT speculate: no "likely", "probably", "suggests", "may indicate", "potentially"</li>
+    <li>DO NOT infer correlations between separate data points — only cite what appears in the SAME filtered view</li>
+    <li>If the cross-reference shows errors ON a page, you can state that. If it doesn't, don't claim it</li>
+    <li>DO NOT mention conversion pages (signup, checkout, contact) unless the cross-reference data explicitly shows errors on those URLs. Generic statements like "preventing users from reaching conversion pages" without a linked page URL are banned</li>
+    <li>The UX consequence paragraph MUST also be linked — if you say "users experience broken navigation", link to the specific error type and page where it happens. Every consequence claim needs a data-facet span pointing to the proof</li>
+  </ul>
+
+  <p><b>STYLE:</b> Natural flowing paragraphs with 2-3 bullets where listing specifics. Every data point linked. Don't open with the dry error rate percentage — open with the pages where errors hit hardest. If you state a count ("dominated by two patterns"), the number of items that follow MUST match exactly — don't say "two" then list three.</p>
+
   <p><b>ERROR COUNT ACCURACY:</b></p>
   <ul>
-    <li><b>Use TOTAL from tool</b> when linking to <code>checkpoint=error</code> - don't link your calculated subset</li>
+    <li><b>Use TOTAL from tool</b> when linking to <code>checkpoint=error</code> — don't link your calculated subset</li>
     <li><b>If discussing "top N sources":</b> Mention aggregate WITHOUT link, then detail each source with nested facets</li>
-    <li><b>Example structure:</b> "The site experiences <code>&lt;span data-facet="checkpoint" data-facet-value="error"&gt;7.6m total errors&lt;/span&gt;</code> (~2.7% of traffic), with 5.8m concentrated in the top 5 sources. Leading issues include <code>&lt;span data-nested-facet="error.source" data-nested-value="serialization"&gt;2.1m serialization errors&lt;/span&gt;</code>, <code>&lt;span data-nested-facet="error.source" data-nested-value="network"&gt;1.8m network errors&lt;/span&gt;</code>, and <code>&lt;span data-nested-facet="error.target" data-nested-value="TypeError"&gt;1.2m TypeErrors&lt;/span&gt;</code>."</li>
   </ul>
+
   <p><b>TWO-LEVEL NESTED ERRORS:</b> If discussing errors with BOTH source AND target (e.g., "network TypeErrors"), use BOTH nested facets so both checkboxes enable.</p>
-  <p>2-3 paragraphs analyzing error patterns. Write flowing narrative; use bullets when listing 3+ specific errors. End with UX impact and recommendations.</p>
+
+  <p><b>LINKING RULES:</b></p>
+  <ul>
+    <li><b>Page references:</b> <code>&lt;span data-facet="url" data-facet-value="/path"&gt;page (COUNT errors)&lt;/span&gt;</code></li>
+    <li><b>Error sources:</b> <code>&lt;span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.source" data-nested-value="SOURCE"&gt;description&lt;/span&gt;</code></li>
+    <li><b>Error targets:</b> <code>&lt;span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.target" data-nested-value="TARGET"&gt;description&lt;/span&gt;</code></li>
+    <li><b>Error on a specific page (URL context):</b> Add <code>data-url-context="/path"</code> to error links when discussing errors that occur on a specific page. This enables BOTH the error checkbox AND the URL checkbox in the dashboard, showing the exact correlation. Example: <code>&lt;span data-facet="checkpoint" data-facet-value="error" data-nested-facet="error.source" data-nested-value="network" data-url-context="/track"&gt;network errors on /track&lt;/span&gt;</code></li>
+    <li><b>Device segments:</b> <code>&lt;span data-facet="userAgent" data-facet-value="VALUE"&gt;description&lt;/span&gt;</code></li>
+    <li><b>No unlinked data points.</b> Every page, error type, device, or count mentioned MUST be linked</li>
+    <li><b>No unproven claims.</b> Only cite what the cross-reference data explicitly shows</li>
+  </ul>
+  <p><b>WHEN TO USE data-url-context:</b> Use it when citing errors from the PER-PAGE ERROR BREAKDOWN. The cross-reference proves these errors occur on that specific page, so the link should filter to BOTH error type + page URL for easy validation.</p>
 
   <h4>PERFORMANCE IMPACT</h4>
-  <p>100-150 words. LCP/CLS/INP values, threshold comparisons, mobile vs desktop, impact on users/SEO. Link each CWV mention. Flowing narrative; bullets when needed.</p>
+  <p>100-150 words. Lead with the WORST CWV metrics — items with <code>"status": "poor"</code> and especially <code>"significant": true</code>. These are proven failures, not noise.</p>
+  <ul>
+    <li><b>Prioritize:</b> poor+significant > poor > needs-improvement. Skip metrics that are passing unless they provide useful contrast (e.g., "desktop LCP passes at 1.8s but mobile fails at 3.4s")</li>
+    <li><b>Quantify impact:</b> Compare to thresholds (LCP: 2.5s, CLS: 0.1, INP: 200ms). State what's failing and by how much</li>
+    <li><b>Break down by segment:</b> Mobile vs desktop, top pages vs site-wide. Highlight where poor CWV concentrates</li>
+    <li><b>Connect to consequences:</b> Poor LCP → SEO ranking penalty, user abandonment. Poor INP → broken interactions. Poor CLS → accidental clicks, frustration</li>
+    <li><b>Skip if all green:</b> If ALL CWV are passing (status: good), state that in 1-2 sentences and move on — don't invent problems</li>
+  </ul>
 
   <h4>USER ENGAGEMENT</h4>
-  <p>100-150 words. Sessions, page views, bounce rates, device breakdown. Connect to performance. Link device + engagement insights. Flowing narrative; bullets when needed.</p>
+  <p>100-150 words. Focus on signals that indicate problems or opportunities — not vanity metrics.</p>
+  <ul>
+    <li><b>Lead with:</b> Bounce rate (critical if >60%), engagement rate (critical if <25%), device split showing poor mobile engagement</li>
+    <li><b>Highlight disparities:</b> If mobile bounce is 2x desktop, that's the story — not total page views</li>
+    <li><b>Connect to CWV:</b> If a device segment has poor CWV (from tool data), connect it to its engagement metrics. "Mobile users experience 3.4s LCP and bounce at 68%" is provable if both data points come from the userAgent facet</li>
+    <li><b>Skip unremarkable:</b> Don't report session counts unless they reveal something (e.g., dramatic drop, unexpected ratio)</li>
+  </ul>
 
   <h4>TRAFFIC & ACQUISITION</h4>
-  <p>100-150 words. Traffic sources with counts, conversion comparison. Link traffic source insights. Flowing narrative; bullets when needed.</p>
+  <p>100-150 words. Focus on what's working, what's not, and where opportunity exists.</p>
+  <ul>
+    <li><b>Lead with:</b> Dominant traffic sources and their conversion effectiveness. If paid traffic has poor CWV (status: poor, significant), that's wasted spend — highlight it</li>
+    <li><b>Highlight imbalances:</b> Heavy reliance on one channel, high-volume sources with poor engagement, underperforming paid vs organic</li>
+    <li><b>Use acquisition facet data:</b> Only cite sources that appear in tool responses with counts</li>
+    <li><b>Skip generic:</b> Don't list all sources with counts — focus on the 2-3 that tell a story</li>
+  </ul>
 
   <h4>CONTENT EFFECTIVENESS</h4>
-  <p>100-150 words. Top pages, underperformers, content strategy. Link page URL insights. Flowing narrative; bullets when needed.</p>
+  <p>100-150 words. Focus on pages that need attention based on data signals.</p>
+  <ul>
+    <li><b>Lead with:</b> Pages with poor CWV (status: poor from url facet), high bounce, or low engagement — these are underperforming despite traffic</li>
+    <li><b>Highlight:</b> High-traffic pages with problems (poor performance, high errors, low conversion). Low-traffic pages that convert well (opportunity to drive more traffic)</li>
+    <li><b>Use url facet data:</b> Cite specific page paths and their metrics from tool responses</li>
+    <li><b>Skip:</b> Don't list top pages by traffic unless their metrics reveal issues. "Homepage gets most views" is not an insight</li>
+  </ul>
 
   <h4>CONVERSION FUNNEL</h4>
-  <p>100-150 words. User journey, drop-off points, opportunity size. Link checkpoint/URL insights. Flowing narrative; bullets when needed.</p>
+  <p>100-150 words. Focus on where users drop off and why.</p>
+  <ul>
+    <li><b>Lead with:</b> The biggest drop-off point in the funnel (if convert/click checkpoint data exists). Quantify the gap — "X users click but only Y convert"</li>
+    <li><b>Connect to problems:</b> If pages in the conversion path have poor CWV or errors (from cross-reference data), that's likely causing the drop-off</li>
+    <li><b>Quantify opportunity:</b> "Fixing the 3.4s LCP on /checkout could recover Z% of the N users who bounce there"</li>
+    <li><b>Skip if no data:</b> If no convert checkpoint or click funnel data exists, keep this section brief — don't speculate about journeys without data</li>
+  </ul>
 
   <h4>GEOGRAPHIC INSIGHTS</h4>
-  <p>100-150 words. User locations, regional variations. Link geo insights if facet exists. Flowing narrative; bullets when needed.</p>
+  <p>100-150 words. Only include if geographic/locale data exists in tool responses.</p>
+  <ul>
+    <li><b>Lead with:</b> Regions with poor CWV (status: poor) or disproportionate error rates — users in those regions have a broken experience</li>
+    <li><b>Highlight:</b> Performance gaps between regions (e.g., "users in region X experience 5.2s LCP vs 2.1s globally"). Regions where errors concentrate</li>
+    <li><b>Skip if no signal:</b> If geographic data shows even distribution with no poor metrics, state "No significant regional variations" in 1 sentence</li>
+  </ul>
 
   <h4>MARKET OPPORTUNITIES</h4>
-  <p>100-150 words. Quick wins, growth potential. Link only if referencing specific facet data. Flowing narrative; bullets when needed.</p>
+  <p>100-150 words. Actionable growth opportunities backed by data.</p>
+  <ul>
+    <li><b>Lead with:</b> Quick wins where fixing a data-proven problem unlocks value — e.g., "fixing mobile LCP would improve experience for 65% of traffic"</li>
+    <li><b>Base on data:</b> Every opportunity must reference a specific metric or finding from earlier sections. Not generic advice</li>
+    <li><b>Quantify:</b> "N users/month affected", "X% of traffic on this segment", "Y conversion gap"</li>
+    <li><b>Skip generic:</b> Don't suggest "SEO improvements" or "expand to new markets" without data showing the opportunity</li>
+  </ul>
 
   <h4>BUSINESS IMPACT</h4>
-  <p>100-150 words. Technical issues → business outcomes, quantified costs. Link key insights. Flowing narrative; bullets when needed.</p>
+  <p>100-150 words. Translate the technical findings into business cost.</p>
+  <ul>
+    <li><b>Lead with:</b> The highest-cost problem. Errors on conversion pages, poor CWV on high-traffic pages, broken device segments — whichever costs the business most</li>
+    <li><b>Quantify in business terms:</b> "N users/month hit errors on conversion pages", "X% of mobile sessions bounce due to slow load", "Y broken experiences per day on the primary funnel"</li>
+    <li><b>Reference earlier data:</b> This section synthesizes — it should cite the same data points (linked) from Performance, Errors, Engagement sections. Don't introduce new findings here</li>
+    <li><b>Rank by severity:</b> Revenue impact > user experience > SEO > brand perception</li>
+  </ul>
 
   <h4>PRIORITY ACTIONS</h4>
   <p><b>Edge Delivery Services SITE HANDLING:</b></p>
@@ -200,8 +280,10 @@
 
   <p><b>Standard Priority Actions Structure:</b></p>
   <p>List 4-6 quick wins (HIGH IMPACT + EASY FIX) when real issues exist. 2-3 high-impact actions when site is performing well. NO long-term projects or timelines.</p>
-  <p><b>Authoring Tasks (2-3 when needed):</b> Broken links, alt text, metadata, content improvements (NOT WebP for EDS sites)</p>
-  <p><b>Code Tasks (2-3 when needed):</b> Caching, error fixes, performance tweaks specific to actual problems (NOT image format for EDS sites)</p>
+  <p><b>EXACT category names (do NOT rename or invent others):</b></p>
+  <p><b>Content Actions (2-3 when needed):</b> Broken links, alt text, metadata, content improvements (NOT WebP for EDS sites)</p>
+  <p><b>Code Actions (2-3 when needed):</b> Caching, error fixes, performance tweaks specific to actual problems (NOT image format for EDS sites)</p>
+  <p><b>DO NOT use other category names</b> like "Infrastructure Tasks", "Technical Tasks", "Monitoring Tasks", etc. ALL actions must go under either "Content Actions" or "Code Actions".</p>
   <p><b>Prioritize:</b> (1) Real issues with data backing, (2) Quick wins, (3) High traffic impact, (4) CWV issues (if failing), (5) Revenue-impacting</p>
   <p><b>Format:</b> Wrap action in facet link, leave "Expected Impact:" unlinked</p>
   <pre>&lt;p&gt;• &lt;span data-facet="checkpoint" data-facet-value="cwv-lcp"&gt;Implement responsive images with srcset.&lt;/span&gt; Expected Impact: Reduce LCP from 3.3s toward 2.5s.&lt;/p&gt;</pre>


### PR DESCRIPTION
## Summary
- Cross-reference JS errors with pages and devices for data-backed business impact insights
- Enrich facet data with CWV severity signals (poor/needs-improvement/significant) for prioritization
- Add URL context linking (`data-url-context`) to enable correlated error + page filtering in dashboard
- Prevent AI from pre-stating item counts before lists

## Test plan
- [ ] Generate a report on a domain with JS errors and verify the JS Errors section contains only linked, data-backed findings
- [ ] Click facet links in the report and verify dashboard filters match the stated data
- [ ] Confirm no count mismatches in generated reports
- [ ] Verify `data-url-context` links enable both error and URL checkboxes in dashboard

Preview: https://optel-report--helix-tools-website--adobe.aem.page/tools/optel/oversight/explorer.html?domain=www.crucial.com&filter=&view=week&=performance&domainkey=incognito&endDate=2026-06-17&report=2026-06-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)