### PR TITLE
feat(user-admin): add requireAuth config field for site access

### DIFF
--- a/tests/tools/user-admin/utils.test.js
+++ b/tests/tools/user-admin/utils.test.js
@@ -109,6 +109,17 @@ describe('user-admin:utils.js', () => {
       assert.deepEqual(result.admin.role, { author: ['a@b.com'] });
     });
 
+    it('always sets admin.requireAuth to auto', () => {
+      const result = buildAccessConfig({}, []);
+      assert.equal(result.admin.requireAuth, 'auto');
+    });
+
+    it('overwrites an existing admin.requireAuth value with auto', () => {
+      const original = { admin: { role: {}, requireAuth: 'true' } };
+      const result = buildAccessConfig(original, []);
+      assert.equal(result.admin.requireAuth, 'auto');
+    });
+
     it('is the inverse of parseUsersFromAccessConfig', () => {
       const original = {
         admin: {

--- a/tools/user-admin/user-admin.css
+++ b/tools/user-admin/user-admin.css
@@ -531,38 +531,3 @@ dialog.user-admin-modal.confirm-dialog {
     transform: translateY(50%);
   }
 }
-
-/* Config Section (requireAuth row) */
-.user-admin #users-container .config-section {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-m);
-  padding: var(--spacing-s) var(--horizontal-spacing);
-  border-top: 1px solid var(--color-border);
-  margin-top: var(--spacing-m);
-  flex-wrap: wrap;
-}
-
-.user-admin #users-container .config-section label {
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.user-admin #users-container .config-section select {
-  width: 7rem;
-  padding: var(--spacing-xs) var(--spacing-s);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  background: var(--color-background);
-  color: var(--color-text);
-}
-
-.user-admin #users-container .config-section .config-save-btn {
-  font-size: var(--body-size-s);
-}
-
-.user-admin #users-container .config-section .config-error {
-  color: var(--red-600);
-  font-size: var(--body-size-s);
-  width: 100%;
-}

--- a/tools/user-admin/user-admin.css
+++ b/tools/user-admin/user-admin.css
@@ -531,3 +531,38 @@ dialog.user-admin-modal.confirm-dialog {
     transform: translateY(50%);
   }
 }
+
+/* Config Section (requireAuth row) */
+.user-admin #users-container .config-section {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-m);
+  padding: var(--spacing-s) var(--horizontal-spacing);
+  border-top: 1px solid var(--color-border);
+  margin-top: var(--spacing-m);
+  flex-wrap: wrap;
+}
+
+.user-admin #users-container .config-section label {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.user-admin #users-container .config-section select {
+  width: 7rem;
+  padding: var(--spacing-xs) var(--spacing-s);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.user-admin #users-container .config-section .config-save-btn {
+  font-size: var(--body-size-s);
+}
+
+.user-admin #users-container .config-section .config-error {
+  color: var(--red-600);
+  font-size: var(--body-size-s);
+  width: 100%;
+}

--- a/tools/user-admin/user-admin.js
+++ b/tools/user-admin/user-admin.js
@@ -13,9 +13,7 @@ const site = document.getElementById('site');
 const org = document.getElementById('org');
 const consoleBlock = document.querySelector('.console');
 const usersContainer = document.getElementById('users-container');
-const accessConfig = {
-  type: 'org', users: [], originalSiteAccess: {}, requireAuth: 'auto',
-};
+const accessConfig = { type: 'org', users: [], originalSiteAccess: {} };
 
 const ROLES = ['admin', 'author', 'publish', 'develop', 'basic_author', 'basic_publish', 'config', 'config_admin'];
 
@@ -92,9 +90,9 @@ async function getSiteAccessConfig() {
   return result.ok ? result.json() : null;
 }
 
-async function updateSiteAccess(requireAuth = accessConfig.requireAuth) {
+async function updateSiteAccess() {
   const { originalSiteAccess, users } = accessConfig;
-  const access = buildAccessConfig(originalSiteAccess, users, requireAuth);
+  const access = buildAccessConfig(originalSiteAccess, users);
   const result = await executeAdminRequest(
     async () => {
       const res = await admin.config({ org: org.value, site: site.value })
@@ -755,58 +753,6 @@ function createUserCard(user) {
   return card;
 }
 
-function displayConfigSection(container) {
-  const section = document.createElement('div');
-  section.className = 'config-section';
-
-  const label = document.createElement('label');
-  label.htmlFor = 'require-auth-select';
-  label.textContent = 'Require Auth';
-
-  const select = document.createElement('select');
-  select.id = 'require-auth-select';
-  select.name = 'requireAuth';
-  [['auto', 'Auto'], ['true', 'True'], ['false', 'False']].forEach(([val, text]) => {
-    const opt = document.createElement('option');
-    opt.value = val;
-    opt.textContent = text;
-    if (val === accessConfig.requireAuth) opt.selected = true;
-    select.appendChild(opt);
-  });
-
-  const errorSpan = document.createElement('span');
-  errorSpan.className = 'config-error';
-  errorSpan.hidden = true;
-
-  const saveBtn = document.createElement('button');
-  saveBtn.type = 'button';
-  saveBtn.className = 'button config-save-btn';
-  saveBtn.textContent = 'Save';
-
-  saveBtn.addEventListener('click', async () => {
-    const { value } = select;
-    errorSpan.hidden = true;
-    saveBtn.disabled = true;
-    saveBtn.textContent = 'Saving…';
-    const success = await updateSiteAccess(value);
-    if (success) accessConfig.requireAuth = value;
-    saveBtn.disabled = false;
-    saveBtn.textContent = 'Save';
-    if (success) {
-      showToast('Config saved');
-    } else {
-      errorSpan.textContent = 'Failed to save config';
-      errorSpan.hidden = false;
-    }
-  });
-
-  section.appendChild(label);
-  section.appendChild(select);
-  section.appendChild(saveBtn);
-  section.appendChild(errorSpan);
-  container.appendChild(section);
-}
-
 function displayUsers(users) {
   usersContainer.innerHTML = '';
 
@@ -882,10 +828,6 @@ function displayUsers(users) {
   });
 
   usersContainer.appendChild(grid);
-
-  if (accessConfig.type === 'site') {
-    displayConfigSection(usersContainer);
-  }
 }
 
 adminForm.addEventListener('submit', async (e) => {
@@ -901,7 +843,6 @@ adminForm.addEventListener('submit', async (e) => {
     }
 
     accessConfig.originalSiteAccess = config;
-    accessConfig.requireAuth = config.admin?.requireAuth ?? 'auto';
     accessConfig.users = parseUsersFromAccessConfig(config);
     displayUsers(accessConfig.users);
   } else {

--- a/tools/user-admin/user-admin.js
+++ b/tools/user-admin/user-admin.js
@@ -13,7 +13,9 @@ const site = document.getElementById('site');
 const org = document.getElementById('org');
 const consoleBlock = document.querySelector('.console');
 const usersContainer = document.getElementById('users-container');
-const accessConfig = { type: 'org', users: [], originalSiteAccess: {} };
+const accessConfig = {
+  type: 'org', users: [], originalSiteAccess: {}, requireAuth: 'auto',
+};
 
 const ROLES = ['admin', 'author', 'publish', 'develop', 'basic_author', 'basic_publish', 'config', 'config_admin'];
 
@@ -90,8 +92,9 @@ async function getSiteAccessConfig() {
   return result.ok ? result.json() : null;
 }
 
-async function updateSiteAccess() {
-  const access = buildAccessConfig(accessConfig.originalSiteAccess, accessConfig.users);
+async function updateSiteAccess(requireAuth = accessConfig.requireAuth) {
+  const { originalSiteAccess, users } = accessConfig;
+  const access = buildAccessConfig(originalSiteAccess, users, requireAuth);
   const result = await executeAdminRequest(
     async () => {
       const res = await admin.config({ org: org.value, site: site.value })
@@ -752,6 +755,58 @@ function createUserCard(user) {
   return card;
 }
 
+function displayConfigSection(container) {
+  const section = document.createElement('div');
+  section.className = 'config-section';
+
+  const label = document.createElement('label');
+  label.htmlFor = 'require-auth-select';
+  label.textContent = 'Require Auth';
+
+  const select = document.createElement('select');
+  select.id = 'require-auth-select';
+  select.name = 'requireAuth';
+  [['auto', 'Auto'], ['true', 'True'], ['false', 'False']].forEach(([val, text]) => {
+    const opt = document.createElement('option');
+    opt.value = val;
+    opt.textContent = text;
+    if (val === accessConfig.requireAuth) opt.selected = true;
+    select.appendChild(opt);
+  });
+
+  const errorSpan = document.createElement('span');
+  errorSpan.className = 'config-error';
+  errorSpan.hidden = true;
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
+  saveBtn.className = 'button config-save-btn';
+  saveBtn.textContent = 'Save';
+
+  saveBtn.addEventListener('click', async () => {
+    const { value } = select;
+    errorSpan.hidden = true;
+    saveBtn.disabled = true;
+    saveBtn.textContent = 'Saving…';
+    const success = await updateSiteAccess(value);
+    if (success) accessConfig.requireAuth = value;
+    saveBtn.disabled = false;
+    saveBtn.textContent = 'Save';
+    if (success) {
+      showToast('Config saved');
+    } else {
+      errorSpan.textContent = 'Failed to save config';
+      errorSpan.hidden = false;
+    }
+  });
+
+  section.appendChild(label);
+  section.appendChild(select);
+  section.appendChild(saveBtn);
+  section.appendChild(errorSpan);
+  container.appendChild(section);
+}
+
 function displayUsers(users) {
   usersContainer.innerHTML = '';
 
@@ -827,6 +882,10 @@ function displayUsers(users) {
   });
 
   usersContainer.appendChild(grid);
+
+  if (accessConfig.type === 'site') {
+    displayConfigSection(usersContainer);
+  }
 }
 
 adminForm.addEventListener('submit', async (e) => {
@@ -842,6 +901,7 @@ adminForm.addEventListener('submit', async (e) => {
     }
 
     accessConfig.originalSiteAccess = config;
+    accessConfig.requireAuth = config.admin?.requireAuth ?? 'auto';
     accessConfig.users = parseUsersFromAccessConfig(config);
     displayUsers(accessConfig.users);
   } else {

--- a/tools/user-admin/utils.js
+++ b/tools/user-admin/utils.js
@@ -29,8 +29,11 @@ export function parseUsersFromAccessConfig(config) {
  * @param {{ email: string, roles: string[] }[]} users
  * @returns {object} Updated access config ready to POST back
  */
-export function buildAccessConfig(originalAccess, users) {
+export function buildAccessConfig(originalAccess, users, requireAuth) {
   const access = { ...originalAccess, admin: { ...originalAccess?.admin, role: {} } };
+  if (requireAuth !== undefined) {
+    access.admin.requireAuth = requireAuth;
+  }
   users.forEach((user) => {
     user.roles.forEach((role) => {
       if (!access.admin.role[role]) access.admin.role[role] = [user.email];

--- a/tools/user-admin/utils.js
+++ b/tools/user-admin/utils.js
@@ -29,11 +29,8 @@ export function parseUsersFromAccessConfig(config) {
  * @param {{ email: string, roles: string[] }[]} users
  * @returns {object} Updated access config ready to POST back
  */
-export function buildAccessConfig(originalAccess, users, requireAuth) {
-  const access = { ...originalAccess, admin: { ...originalAccess?.admin, role: {} } };
-  if (requireAuth !== undefined) {
-    access.admin.requireAuth = requireAuth;
-  }
+export function buildAccessConfig(originalAccess, users) {
+  const access = { ...originalAccess, admin: { ...originalAccess?.admin, role: {}, requireAuth: 'auto' } };
   users.forEach((user) => {
     user.roles.forEach((role) => {
       if (!access.admin.role[role]) access.admin.role[role] = [user.email];


### PR DESCRIPTION
## Summary

- `buildAccessConfig` now always writes `"requireAuth": "auto"` inside the `admin` object of `access.json` when site users are saved
- The previously-added UI dropdown and config section have been removed — the property is set implicitly, not user-configurable

## Changes

- `tools/user-admin/utils.js` — `buildAccessConfig` hardcodes `requireAuth: 'auto'` in the `admin` object; the third parameter is removed
- `tools/user-admin/user-admin.js` — reverted state, `updateSiteAccess()` signature, and removed `displayConfigSection()`
- `tools/user-admin/user-admin.css` — removed `.config-section` styles

## Preview

https://feat-user-admin-require-auth--helix-tools-website--adobe.aem.page/tools/user-admin/

## Test plan

- [x] Fetch a site and edit a user's roles — confirm `access.json` in the console contains `"requireAuth": "auto"` inside `admin`
- [x] No "Require Auth" field visible in the UI
- [x] 544 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)