### PR TITLE
fix: get reviewHost and liveHost from sidekick config and not url params in Review Pallete

### DIFF
--- a/tools/snapshot-admin/palette.js
+++ b/tools/snapshot-admin/palette.js
@@ -5,6 +5,7 @@ import {
   fetchStatus,
   updateReviewStatus,
 } from './snapshot-utils.js';
+import admin from '../../scripts/helix-admin.js';
 
 const params = new URLSearchParams(window.location.search);
 const referrer = new URL(params.get('referrer'));
@@ -13,18 +14,9 @@ const REPO = params.get('repo');
 const SNAPSHOT = 'default';
 const PATHNAME = referrer.pathname;
 
-const ALLOWED_HOST_SUFFIXES = ['.aem.reviews', '.aem.live', '.aem.page'];
-
-function isTrustedHost(host) {
-  if (!host) return false;
-  const normalized = host.toLowerCase().trim();
-  return ALLOWED_HOST_SUFFIXES.some(
-    (suffix) => normalized === suffix.slice(1) || normalized.endsWith(suffix),
-  );
-}
-
-const CUSTOM_REVIEW_HOST = isTrustedHost(params.get('reviewHost')) ? params.get('reviewHost') : null;
-const CUSTOM_LIVE_HOST = isTrustedHost(params.get('liveHost')) ? params.get('liveHost') : null;
+// Populated from the sidekick config in init() — not taken from URL params.
+let customReviewHost = null;
+let customLiveHost = null;
 
 const ADD = document.getElementById('add-page');
 const REMOVE = document.getElementById('remove-page');
@@ -43,7 +35,16 @@ const PAGE_STATUS_WRAPPER = document.getElementById('page-status-wrapper');
 async function init() {
   const state = referrer.hostname.includes('reviews') ? 'review' : 'page';
 
-  REVIEWS_LINK.href = CUSTOM_REVIEW_HOST ? `https://${CUSTOM_REVIEW_HOST}${PATHNAME}` : `https://${SNAPSHOT}--main--${REPO}--${OWNER}.aem.reviews${PATHNAME}`;
+  try {
+    const result = await admin.sidekick({ org: OWNER, site: REPO }).get('config.json');
+    if (result.ok) {
+      const json = await result.json();
+      customReviewHost = json.reviewHost || null;
+      customLiveHost = json.liveHost || null;
+    }
+  } catch { /* use defaults */ }
+
+  REVIEWS_LINK.href = customReviewHost ? `https://${customReviewHost}${PATHNAME}` : `https://${SNAPSHOT}--main--${REPO}--${OWNER}.aem.reviews${PATHNAME}`;
   ADMIN_LINK.href = `/tools/snapshot-admin/index.html?snapshot=https://main--${REPO}--${OWNER}.aem.page/.snapshots/${SNAPSHOT}/.manifest.json`;
 
   if (state === 'page') {
@@ -153,7 +154,7 @@ REVIEW_REJECT.addEventListener('click', async () => {
 REVIEW_APPROVE.addEventListener('click', async () => {
   SPINNER.setAttribute('aria-hidden', 'false');
   await updateReviewStatus(OWNER, REPO, SNAPSHOT, 'approve');
-  window.parent.location.href = CUSTOM_LIVE_HOST ? `https://${CUSTOM_LIVE_HOST}${PATHNAME}` : `https://main--${REPO}--${OWNER}.aem.live${PATHNAME}`;
+  window.parent.location.href = customLiveHost ? `https://${customLiveHost}${PATHNAME}` : `https://main--${REPO}--${OWNER}.aem.live${PATHNAME}`;
 });
 
 init();

--- a/tools/snapshot-admin/palette.js
+++ b/tools/snapshot-admin/palette.js
@@ -5,7 +5,7 @@ import {
   fetchStatus,
   updateReviewStatus,
 } from './snapshot-utils.js';
-import admin from '../../scripts/helix-admin.js';
+import getAdminClient from '../../scripts/admin-compat.js';
 
 const params = new URLSearchParams(window.location.search);
 const referrer = new URL(params.get('referrer'));
@@ -36,6 +36,7 @@ async function init() {
   const state = referrer.hostname.includes('reviews') ? 'review' : 'page';
 
   try {
+    const admin = await getAdminClient();
     const result = await admin.sidekick({ org: OWNER, site: REPO }).get('config.json');
     if (result.ok) {
       const json = await result.json();

--- a/tools/snapshot-admin/palette.js
+++ b/tools/snapshot-admin/palette.js
@@ -10,10 +10,21 @@ const params = new URLSearchParams(window.location.search);
 const referrer = new URL(params.get('referrer'));
 const OWNER = params.get('owner');
 const REPO = params.get('repo');
-const CUSTOM_REVIEW_HOST = params.get('reviewHost');
-const CUSTOM_LIVE_HOST = params.get('liveHost');
 const SNAPSHOT = 'default';
 const PATHNAME = referrer.pathname;
+
+const ALLOWED_HOST_SUFFIXES = ['.aem.reviews', '.aem.live', '.aem.page'];
+
+function isTrustedHost(host) {
+  if (!host) return false;
+  const normalized = host.toLowerCase().trim();
+  return ALLOWED_HOST_SUFFIXES.some(
+    (suffix) => normalized === suffix.slice(1) || normalized.endsWith(suffix),
+  );
+}
+
+const CUSTOM_REVIEW_HOST = isTrustedHost(params.get('reviewHost')) ? params.get('reviewHost') : null;
+const CUSTOM_LIVE_HOST = isTrustedHost(params.get('liveHost')) ? params.get('liveHost') : null;
 
 const ADD = document.getElementById('add-page');
 const REMOVE = document.getElementById('remove-page');
@@ -32,7 +43,7 @@ const PAGE_STATUS_WRAPPER = document.getElementById('page-status-wrapper');
 async function init() {
   const state = referrer.hostname.includes('reviews') ? 'review' : 'page';
 
-  REVIEWS_LINK.href = (CUSTOM_REVIEW_HOST && !CUSTOM_REVIEW_HOST.endsWith('.aem.reviews')) ? `https://${CUSTOM_REVIEW_HOST}${PATHNAME}` : `https://${SNAPSHOT}--main--${REPO}--${OWNER}.aem.reviews${PATHNAME}`;
+  REVIEWS_LINK.href = CUSTOM_REVIEW_HOST ? `https://${CUSTOM_REVIEW_HOST}${PATHNAME}` : `https://${SNAPSHOT}--main--${REPO}--${OWNER}.aem.reviews${PATHNAME}`;
   ADMIN_LINK.href = `/tools/snapshot-admin/index.html?snapshot=https://main--${REPO}--${OWNER}.aem.page/.snapshots/${SNAPSHOT}/.manifest.json`;
 
   if (state === 'page') {

--- a/tools/snapshot-admin/popover.js
+++ b/tools/snapshot-admin/popover.js
@@ -11,9 +11,11 @@ const params = new URLSearchParams(window.location.search);
 const referrer = new URL(params.get('referrer'));
 const OWNER = params.get('owner');
 const REPO = params.get('repo');
-const CUSTOM_REVIEW_HOST = params.get('reviewHost');
-const CUSTOM_LIVE_HOST = params.get('liveHost');
 const PATHNAME = referrer.pathname;
+
+// Populated from the sidekick config in init() — not taken from URL params.
+let customReviewHost = null;
+let customLiveHost = null;
 
 // UI Elements
 const SNAPSHOT_SELECT = document.getElementById('snapshot-select');
@@ -54,8 +56,8 @@ async function updateSnapshotUI() {
   const state = referrer.hostname.includes('reviews') ? 'review' : 'page';
 
   // Update links
-  REVIEWS_LINK.href = (CUSTOM_REVIEW_HOST && !CUSTOM_REVIEW_HOST.endsWith('.aem.reviews'))
-    ? `https://${CUSTOM_REVIEW_HOST}${PATHNAME}`
+  REVIEWS_LINK.href = customReviewHost
+    ? `https://${customReviewHost}${PATHNAME}`
     : `https://${currentSnapshot}--main--${REPO}--${OWNER}.aem.reviews${PATHNAME}`;
 
   ADMIN_LINK.href = `/tools/snapshot-admin/snapshot-details.html?snapshot=https://main--${REPO}--${OWNER}.aem.page/.snapshots/${currentSnapshot}/.manifest.json`;
@@ -174,8 +176,7 @@ async function onSnapshotChange() {
   await updateSnapshotUI();
 }
 
-async function loadSnapshots() {
-  const admin = await getAdminClient();
+async function loadSnapshots(admin) {
   try {
     const result = await admin.snapshot({ org: OWNER, site: REPO }).get();
 
@@ -258,15 +259,24 @@ REVIEW_APPROVE.addEventListener('click', async () => {
   if (!currentSnapshot) return;
   SPINNER.setAttribute('aria-hidden', 'false');
   await updateReviewStatus(OWNER, REPO, currentSnapshot, 'approve');
-  window.parent.location.href = CUSTOM_LIVE_HOST
-    ? `https://${CUSTOM_LIVE_HOST}${PATHNAME}`
+  window.parent.location.href = customLiveHost
+    ? `https://${customLiveHost}${PATHNAME}`
     : `https://main--${REPO}--${OWNER}.aem.live${PATHNAME}`;
 });
 
 // Initialize
 async function init() {
   SPINNER.setAttribute('aria-hidden', 'false');
-  await loadSnapshots();
+  const admin = await getAdminClient();
+  try {
+    const result = await admin.sidekick({ org: OWNER, site: REPO }).get('config.json');
+    if (result.ok) {
+      const json = await result.json();
+      customReviewHost = json.reviewHost || null;
+      customLiveHost = json.liveHost || null;
+    }
+  } catch { /* use defaults */ }
+  await loadSnapshots(admin);
   SPINNER.setAttribute('aria-hidden', 'true');
 }
 


### PR DESCRIPTION
## Summary

Closes the [open redirect vulnerability](https://jira.corp.adobe.com/browse/SITES-47362) in the snapshot-admin palette tool. The root cause was that `reviewHost` and `liveHost` were read directly from URL query parameters and used, without validation, to construct navigation URLs. An attacker could craft a malicious URL that, when clicked, sent the victim's authentication cookies to an attacker-controlled server.

The fix removes `reviewHost` and `liveHost` from the URL params entirely. Both values are now fetched from the sidekick config (`admin.sidekick({ org, site }).get('config.json')`) — an authenticated API call — so they cannot be injected via a crafted URL. This mirrors the pattern already used in `snapshot-details.js`. If the config fetch fails, both fall back to `null` and the default AEM URLs are used.

## Test plan

**Verify the attack vector is closed:**

1. Navigate to:
   ```
   https://fix-snapshot-admin-open-redirect--helix-tools-website--adobe.aem.page/tools/snapshot-admin/palette.html?referrer=https://example.com/page&owner=test&repo=test&reviewHost=attacker.com
   ```
2. Open DevTools console and run:
   ```js
   document.getElementById('go-to-review').href
   ```
3. **Expected:** URL should be the default `https://default--main--test--test.aem.reviews/page`, not `https://attacker.com/page` — the `reviewHost` param is ignored entirely.

**Verify legitimate customer-configured hosts still work:**

1. Set `reviewHost` in the sidekick `config.json` for a test org/site to a custom domain (e.g. `myreviews.example.com`)
2. Open palette.html for that org/site
3. **Expected:** The Review link href becomes `https://myreviews.example.com/page`

**Verify the liveHost redirect on approval:**

1. Set `liveHost` in the sidekick `config.json` to a custom domain
2. Click the Approve button in palette
3. **Expected:** `window.parent` navigates to `https://{customLiveHost}/page`
4. Pass `?liveHost=attacker.com` in the URL — confirm it has no effect on where Approve navigates.
