### PR TITLE
fix(bot-info): convert setup token id to base64url before deleting apiKey

### DIFF
--- a/widgets/bot-info/bot-info.js
+++ b/widgets/bot-info/bot-info.js
@@ -299,7 +299,8 @@ async function submitConfig(api, widget, config, { org, site, newOrg }, consoleB
 async function deleteApiKey(api, { org, site, newOrg }, tokenId, consoleBlock) {
   if (!tokenId) return;
   const node = newOrg ? api.config({ org }) : api.config({ org, site });
-  const res = await logged(consoleBlock, node.select(`apiKeys/${tokenId}.json`).remove());
+  const safeTokenId = tokenId.replace(/\//g, '_').replace(/\+/g, '-');
+  const res = await logged(consoleBlock, node.select(`apiKeys/${safeTokenId}.json`).remove());
   if (!res?.ok) {
     logMessage(consoleBlock, 'warning', ['setup', `Could not remove setup API key: ${res?.error || res?.status || 'network error'}`]);
   }


### PR DESCRIPTION
## What

`deleteApiKey()` in the `bot-info` setup wizard builds the one-time setup key's delete path as `apiKeys/${tokenId}.json`. The `tokenId` is an opaque id captured from the `token_id` URL fragment param and passed through unmodified. Since `admin.select()` does no encoding, a `tokenId` containing raw base64 characters (`/`, `+`) instead of base64url would build a broken/mismatched path, causing the setup key removal to silently fail.

This converts `tokenId` from base64 to base64url (`/` → `_`, `+` → `-`) before building the delete path.

## Why

The one-time setup API key should always be revoked once site setup completes. If the key id contains `/` or `+`, the current unencoded path either points at the wrong resource or 404s, leaving the setup key active indefinitely (best-effort failure is only logged as a warning, so this could go unnoticed).

## How it was tested

- `npm run lint` — clean.
- `npm test` — 710/710 pass.
- Raw widget markup: https://fix-apikey-removal--helix-tools-website--adobe.aem.page/widgets/bot-info/bot-info.html

> Note: like the original wizard PR (#397), the full happy path (including the apiKey deletion call) needs a real setup token/token_id from the bot redirect, so the delete-key request itself can't be exercised on the preview without that flow. The fix is a narrow, isolated character substitution in the path-building code.

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] Test suite passes (`npm test`, 710/710)

🤖 Generated with [Claude Code](https://claude.com/claude-code)