### PR TITLE
fix: use new route

### DIFF
--- a/tools/cdn-check/cdn-check.js
+++ b/tools/cdn-check/cdn-check.js
@@ -995,7 +995,7 @@ async function checkPurge(cdnConfig, sharedPurgeSnapshot = null) {
 
   try {
     // Build purge test request based on CDN type
-    const purgeUrl = 'https://helix-pages.anywhere.run/helix-services/byocdn-push-invalidation/v1';
+    const purgeUrl = 'https://admin.hlx.page/hook/byocdn-push-invalidation/';
 
     // Prepare form data based on CDN type
     const formData = new URLSearchParams();

--- a/tools/cdn-setup/cdn-setup.js
+++ b/tools/cdn-setup/cdn-setup.js
@@ -23,7 +23,7 @@ let admin;
 let originalConfig;
 let validationPassed = false;
 
-const VALIDATION_URL = 'https://helix-pages.anywhere.run/helix-services/byocdn-push-invalidation/v1';
+const VALIDATION_URL = 'https://admin.hlx.page/hook/byocdn-push-invalidation/';
 
 const CDN_FIELDS = {
   fastly: [


### PR DESCRIPTION
Use admin route for BYOCDN push invalidation service

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/
- After: https://use-helix3-byocdn--helix-tools-website--adobe.aem.live/
