### PR TITLE
feat(bulk): add Helix 6 (api.aem.live) support

### DIFF
--- a/scripts/admin-compat.js
+++ b/scripts/admin-compat.js
@@ -1,10 +1,10 @@
-/**
- * Get an admin client appropriate for the active API version.
- *
- * @returns {Promise<object|null>}
- */
-export default async function getAdminClient() {
-  const useH6 = window.localStorage.getItem('use-h6-api') !== null;
+const H6_FLAG = 'use-h6-api';
+
+// Per-site Helix 6 detection is cached (by org/site/ref) for the page lifetime.
+// Values are the in-flight/settled promises so concurrent callers dedupe.
+const detectionCache = new Map();
+
+async function loadAdminModule(useH6) {
   const adminMod = await import(`../scripts/${useH6 ? 'aem' : 'helix'}-admin.js`);
   if (!adminMod?.default) {
     // eslint-disable-next-line no-console
@@ -12,4 +12,59 @@ export default async function getAdminClient() {
     return null;
   }
   return adminMod.default;
+}
+
+/**
+ * Get an admin client appropriate for the active API version.
+ *
+ * Selection is global, driven by the `use-h6-api` localStorage override. For
+ * per-site selection based on the actual backend, use
+ * {@link getAdminClientForSite}.
+ *
+ * @returns {Promise<object|null>}
+ */
+export default async function getAdminClient() {
+  const useH6 = window.localStorage.getItem(H6_FLAG) !== null;
+  return loadAdminModule(useH6);
+}
+
+/**
+ * Determine whether a site is served by the Helix 6 backend (api.aem.live).
+ *
+ * Detection mirrors the sidekick: the legacy admin service advertises the
+ * upgrade via the `x-api-upgrade-available` response header on the site's
+ * sidekick config, present even on unauthenticated (401) responses. The
+ * `use-h6-api` localStorage override forces H6 without a network call.
+ *
+ * @param {{org: string, site: string, ref?: string}} coords
+ * @returns {Promise<boolean>}
+ */
+export async function isHelix6({ org, site, ref = 'main' }) {
+  if (window.localStorage.getItem(H6_FLAG) !== null) return true;
+  if (!org || !site) return false;
+  const key = `${org}/${site}/${ref}`;
+  if (!detectionCache.has(key)) {
+    const probe = (async () => {
+      try {
+        const url = `https://admin.hlx.page/sidekick/${org}/${site}/${ref}/config.json`;
+        const resp = await fetch(url, { credentials: 'omit', cache: 'no-store' });
+        return resp.headers.get('x-api-upgrade-available') === 'true';
+      } catch {
+        return false;
+      }
+    })();
+    detectionCache.set(key, probe);
+  }
+  return detectionCache.get(key);
+}
+
+/**
+ * Get the admin client for a specific site, selecting H5 or H6 based on the
+ * backend the site actually runs on.
+ *
+ * @param {{org: string, site: string, ref?: string}} coords
+ * @returns {Promise<object|null>}
+ */
+export async function getAdminClientForSite(coords) {
+  return loadAdminModule(await isHelix6(coords));
 }

--- a/scripts/aem-admin.js
+++ b/scripts/aem-admin.js
@@ -174,7 +174,8 @@ function createAdmin(defaults = {}) {
   function log(coords) { return bindOperation(opBase('log', coords), ['get', 'update']); }
   function index(coords) { return bindOperation(opBase('index', coords), ['get', 'update', 'remove']); }
   function sitemap(coords) { return bindOperation(opBase('sitemap', coords), ['update']); }
-  function job(coords) { return bindOperation(opBase('job', coords), ['get', 'remove']); }
+  // H6 serves jobs under the plural `jobs` segment: /{org}/sites/{site}/jobs
+  function job(coords) { return bindOperation(opBase('jobs', coords), ['get', 'remove']); }
   function psi(coords) { return bindOperation(opBase('psi', coords), ['get']); }
   function snapshot(coords) { return bindOperation(opBase('snapshot', coords), ['get', 'update', 'remove']); }
   function sidekick(coords) { return bindOperation(opBase('sidekick', coords), ['get']); }

--- a/tests/scripts/admin-compat.test.js
+++ b/tests/scripts/admin-compat.test.js
@@ -13,7 +13,11 @@ mock.module('../../scripts/aem-admin.js', {
   defaultExport: { clientId: 'aem-admin' },
 });
 
-const { default: getAdminClient } = await import('../../scripts/admin-compat.js');
+const {
+  default: getAdminClient,
+  isHelix6,
+  getAdminClientForSite,
+} = await import('../../scripts/admin-compat.js');
 
 describe('getAdminClient()', () => {
   afterEach(() => {
@@ -35,5 +39,101 @@ describe('getAdminClient()', () => {
     window.localStorage.setItem('use-h6-api', 'true');
     const client = await getAdminClient();
     assert.deepEqual(client, { clientId: 'aem-admin' });
+  });
+});
+
+describe('isHelix6()', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    window.localStorage.removeItem('use-h6-api');
+    global.fetch = originalFetch;
+  });
+
+  const stubFetch = (headerValue, { throws = false } = {}) => {
+    const calls = [];
+    global.fetch = async (url, init) => {
+      calls.push({ url, init });
+      if (throws) throw new Error('network down');
+      return { headers: { get: (name) => (name === 'x-api-upgrade-available' ? headerValue : null) } };
+    };
+    return calls;
+  };
+
+  it('returns true when the upgrade header is present', async () => {
+    stubFetch('true');
+    assert.equal(await isHelix6({ org: 'adobe', site: 'aem-website' }), true);
+  });
+
+  it('returns false when the upgrade header is absent', async () => {
+    stubFetch(null);
+    assert.equal(await isHelix6({ org: 'adobe', site: 'helix-tools-website' }), false);
+  });
+
+  it('probes the legacy sidekick config endpoint for the default ref', async () => {
+    const calls = stubFetch('true');
+    await isHelix6({ org: 'o', site: 's' });
+    assert.equal(calls[0].url, 'https://admin.hlx.page/sidekick/o/s/main/config.json');
+    assert.equal(calls[0].init.credentials, 'omit');
+  });
+
+  it('honors an explicit ref', async () => {
+    const calls = stubFetch('true');
+    await isHelix6({ org: 'o', site: 's', ref: 'dev' });
+    assert.equal(calls[0].url, 'https://admin.hlx.page/sidekick/o/s/dev/config.json');
+  });
+
+  it('short-circuits to true on the use-h6-api override without a network call', async () => {
+    window.localStorage.setItem('use-h6-api', '');
+    const calls = stubFetch('false');
+    assert.equal(await isHelix6({ org: 'o', site: 's' }), true);
+    assert.equal(calls.length, 0);
+  });
+
+  it('returns false without a network call when coords are incomplete', async () => {
+    const calls = stubFetch('true');
+    assert.equal(await isHelix6({ org: 'o' }), false);
+    assert.equal(calls.length, 0);
+  });
+
+  it('caches detection per site to dedupe concurrent probes', async () => {
+    const calls = stubFetch('true');
+    const [a, b] = await Promise.all([
+      isHelix6({ org: 'cached', site: 's' }),
+      isHelix6({ org: 'cached', site: 's' }),
+    ]);
+    assert.equal(a, true);
+    assert.equal(b, true);
+    assert.equal(calls.length, 1);
+  });
+
+  it('treats a network error as not-Helix6', async () => {
+    stubFetch(null, { throws: true });
+    assert.equal(await isHelix6({ org: 'err', site: 's' }), false);
+  });
+});
+
+describe('getAdminClientForSite()', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    window.localStorage.removeItem('use-h6-api');
+    global.fetch = originalFetch;
+  });
+
+  it('returns the H6 client for a Helix 6 site', async () => {
+    global.fetch = async () => ({
+      headers: { get: () => 'true' },
+    });
+    const client = await getAdminClientForSite({ org: 'h6org', site: 's' });
+    assert.deepEqual(client, { clientId: 'aem-admin' });
+  });
+
+  it('returns the H5 client for a legacy site', async () => {
+    global.fetch = async () => ({
+      headers: { get: () => null },
+    });
+    const client = await getAdminClientForSite({ org: 'h5org', site: 's' });
+    assert.deepEqual(client, { clientId: 'helix-admin' });
   });
 });

--- a/tests/scripts/aem-admin.test.js
+++ b/tests/scripts/aem-admin.test.js
@@ -220,9 +220,9 @@ describe('aem-admin.js — H6 URL contract', () => {
   });
 
   describe('admin.job(coords) URLs', () => {
-    it('.get("topic/name") hits /{org}/sites/{site}/job/topic/name', async () => {
+    it('.get("topic/name") hits /{org}/sites/{site}/jobs/topic/name', async () => {
       await admin.job({ org: 'adobe', site: 'x' }).get('index/job-123');
-      assert.equal(calls[0].url, 'https://api.aem.live/adobe/sites/x/job/index/job-123');
+      assert.equal(calls[0].url, 'https://api.aem.live/adobe/sites/x/jobs/index/job-123');
     });
   });
 

--- a/tools/bulk/scripts.js
+++ b/tools/bulk/scripts.js
@@ -1,10 +1,9 @@
-import { analyzeUrls } from './utils.js';
-import getAdminClient from '../../scripts/admin-compat.js';
+import { analyzeUrls, extractOrgSite } from './utils.js';
+import { isHelix6, getAdminClientForSite } from '../../scripts/admin-compat.js';
 import { executeAdminRequest, AuthMode } from '../../utils/admin-request.js';
 
 const log = document.getElementById('logger');
 const adminVersion = new URLSearchParams(window.location.search).get('hlx-admin-version');
-const adminVersionParams = adminVersion ? { 'hlx-admin-version': adminVersion } : undefined;
 
 const append = (string, status = 'unknown') => {
   const p = document.createElement('p');
@@ -186,7 +185,6 @@ const showSanitizationWarning = (changes) => {
 
 document.getElementById('urls-form').addEventListener('submit', async (e) => {
   e.preventDefault();
-  const admin = await getAdminClient();
   let counter = 0;
 
   const rawUrls = document.getElementById('urls').value
@@ -228,6 +226,15 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
     append('No valid URLs after sanitization');
     return false;
   }
+
+  // All URLs in a run target the same site; detect the backend from the first
+  // one and pick the matching admin client (H5 admin.hlx.page or H6 api.aem.live).
+  const firstCoords = extractOrgSite(urlsToUse[0]);
+  const isH6 = await isHelix6(firstCoords);
+  const admin = await getAdminClientForSite(firstCoords);
+  const adminVersionParams = adminVersion
+    ? { [isH6 ? 'aem-api-version' : 'hlx-admin-version']: adminVersion }
+    : undefined;
 
   const operation = document.getElementById('operation').dataset.value;
   const slow = document.getElementById('slow').checked;
@@ -282,9 +289,12 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
       const bulkText = `$1/${total} URL(s) bulk ${VERB[operation]}ed on ${owner}/${repo} ${forceUpdate ? '(force update)' : ''}`;
       const bulkLog = append(bulkText.replace('$1', 0));
       const paths = urlsToUse.map((url) => new URL(url).pathname);
+      // H6 requires forceAsync to run bulk jobs past the small synchronous limit.
+      const bulkBody = { paths, forceUpdate };
+      if (isH6) bulkBody.forceAsync = true;
       const bulkResp = await executeAdminRequest(
         () => admin[operation]({ org: owner, site: repo, ref: branch })
-          .update('/*', JSON.stringify({ paths, forceUpdate }), { params: adminVersionParams }),
+          .update('/*', JSON.stringify(bulkBody), { params: adminVersionParams }),
         { org: owner, site: repo, policy: AuthMode.PREFLIGHT_AND_RETRY },
       );
       if (!bulkResp) {
@@ -296,11 +306,14 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
       } else {
         const { job } = await bulkResp.json();
         const { name } = job;
+        // H6 job topics differ from the operation (e.g. live -> live-publish);
+        // trust the topic echoed by the start response. H5 uses the VERB map.
+        const jobTopic = isH6 ? (job.topic || VERB[operation]) : VERB[operation];
         const jobStatusPoll = window.setInterval(async () => {
           try {
             const jobResp = await executeAdminRequest(
               () => admin.job({ org: owner, site: repo, ref: branch })
-                .get(`${VERB[operation]}/${name}/details`),
+                .get(`${jobTopic}/${name}/details`),
               { org: owner, site: repo, policy: AuthMode.NONE },
             );
             const jobStatus = await jobResp.json();
@@ -313,7 +326,8 @@ document.getElementById('urls-form').addEventListener('submit', async (e) => {
             } = jobStatus;
             if (state === 'stopped') {
               window.clearInterval(jobStatusPoll);
-              resources.forEach((res) => append(`${res.path} (${res.status})`, res.status));
+              // H5 resources carry `path`; H6 carries `resourcePath`.
+              resources.forEach((res) => append(`${res.resourcePath || res.path} (${res.status})`, res.status));
               bulkLog.textContent = bulkText.replace('$1', processed);
               const duration = (new Date(stopTime).valueOf()
                 - new Date(startTime).valueOf()) / 1000;


### PR DESCRIPTION
## What changed

Makes the **bulk** tool work against the Helix 6 admin backend (`api.aem.live`), detecting the site's backend automatically per run and routing bulk preview/publish accordingly.

- **`scripts/admin-compat.js`** — adds per-site detection: `isHelix6({org, site, ref})` probes the site's sidekick config on the legacy admin and reads the CORS-exposed `x-api-upgrade-available` header (present even on 401), mirroring how `aem-sidekick` detects the upgrade. `getAdminClientForSite()` returns the H5 or H6 client based on that. Result is cached per site; the existing `use-h6-api` localStorage override still forces H6.
- **`scripts/aem-admin.js`** — fixes the `job` resource to use the H6 `jobs` (plural) path segment (`/{org}/sites/{site}/jobs`), matching the real admin route.
- **`tools/bulk/scripts.js`** — for H6 bulk jobs: sends `forceAsync: true` (required past the small synchronous path limit, and makes the job pollable), polls by the topic echoed in the start response (`live` → `live-publish`, etc.) instead of the H5 verb map, reads results from `resourcePath` with a `path` fallback, and uses the `aem-api-version` CI param instead of `hlx-admin-version`. H5 behavior is unchanged.

Non-bulk unpreview/unpublish already work through the selected client with no changes.

## Why

The bulk tool only spoke the legacy `admin.hlx.page` API. Sites on Helix 6 use different URL shapes (`/{org}/sites/{site}/…`), require `forceAsync` for bulk, and return different job topics and resource field names.

## Reviewer notes

- The H6 request/response contract was verified directly against the `helix-api-service` source; the detection header + CORS exposure were confirmed with `curl` against a live H6 site (`adobe/aem-website`) and an H5 site.
- Not exercised end-to-end with a live authenticated bulk run (needs an H6 site with content + login). Logic is covered by unit tests.
- Follow-up worth considering: H6 unpreview/unpublish still fire per-URL DELETEs at concurrency 40 vs the documented ~10 req/s admin limit (pre-existing; same on H5). Converting those to the bulk job API with `delete: true` would be more robust.

Tests: 727 pass, 0 fail. Lint clean.

Test URLs:
- Before: https://main--helix-tools-website--adobe.aem.live/tools/bulk/
- After: https://bulk-helix6-support--helix-tools-website--adobe.aem.page/tools/bulk/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)