### PR TITLE
fix(bot-info): stop misdetecting adobeaemcloud URLs as AEM

### DIFF
--- a/tests/widgets/bot-info/wizard.test.js
+++ b/tests/widgets/bot-info/wizard.test.js
@@ -27,13 +27,17 @@ describe('bot-info:wizard.js', () => {
       assert.equal(detectContentSourceKind('https://content.da.live/org/site'), 'da');
     });
 
-    it('detects AEM (api.aem.live and legacy adobeaemcloud)', () => {
+    it('detects AEM (api.aem.live only)', () => {
       assert.equal(detectContentSourceKind('https://api.aem.live/org/sites/site/source'), 'aem');
-      assert.equal(detectContentSourceKind('https://author-p123.adobeaemcloud.com/'), 'aem');
     });
 
-    it('falls back to byom for unknown markup hosts', () => {
+    it('falls back to byom for unknown markup hosts, including adobeaemcloud/franklin.delivery', () => {
       assert.equal(detectContentSourceKind('https://example.com/content'), 'byom');
+      assert.equal(detectContentSourceKind('https://author-p123.adobeaemcloud.com/'), 'byom');
+      assert.equal(
+        detectContentSourceKind('https://author-p130360-e1272151.adobeaemcloud.com/bin/franklin.delivery/adobe-rnd/aem-boilerplate-xwalk/main'),
+        'byom',
+      );
     });
   });
 

--- a/widgets/bot-info/wizard.js
+++ b/widgets/bot-info/wizard.js
@@ -24,8 +24,10 @@ export const CONTENT_SOURCE_KINDS = [
 ];
 
 /**
- * Guess the UI content-source kind from a content URL. Mirrors the detection in
- * site-admin's `buildSiteConfig`/`getContentSourceType`.
+ * Guess the UI content-source kind from a content URL. `aem` only matches the
+ * fixed connector format (`https://api.aem.live/...`) — an `adobeaemcloud.com`
+ * URL is an arbitrary markup source (e.g. a franklin.delivery URL), not that
+ * fixed format, so it falls through to `byom`.
  *
  * @param {string} url
  * @returns {'da'|'aem'|'google'|'onedrive'|'byom'}
@@ -35,7 +37,7 @@ export function detectContentSourceKind(url) {
   if (url.startsWith('https://drive.google.com/drive')) return 'google';
   if (url.includes('sharepoint.com/')) return 'onedrive';
   if (url.startsWith('https://content.da.live')) return 'da';
-  if (url.startsWith('https://api.aem.live/') || url.includes('adobeaemcloud')) return 'aem';
+  if (url.startsWith('https://api.aem.live/')) return 'aem';
   return 'byom';
 }
 


### PR DESCRIPTION
## What

`detectContentSourceKind` in the bot-info setup wizard matched any
`adobeaemcloud.com` URL as the `'aem'` content-source kind via a broad
substring check. That kind is meant only for the fixed connector format
(`https://api.aem.live/...`), not for arbitrary markup URLs that happen to
live on an AEM author cloud domain — e.g. a `franklin.delivery` URL like:

```
https://author-p130360-e1272151.adobeaemcloud.com/bin/franklin.delivery/adobe-rnd/aem-boilerplate-xwalk/main
```

Dropped the `adobeaemcloud` branch entirely, so only `api.aem.live` URLs
detect as `'aem'`; everything else (including `adobeaemcloud.com`) falls
through to `'byom'` ("bring your own markup").

## Why

The misdetection wasn't just a display bug: in `bot-info.js`, the `'aem'`
kind makes the content-source URL field **read-only** and **overwrites** it
with a synthetic `https://api.aem.live/{org}/{site}/source` URL. Since this
runs during the wizard's prefill step, loading a site whose real content
source was an `adobeaemcloud.com`/`franklin.delivery` URL silently discarded
that URL and replaced it with the wrong one.

## How it was tested

- `npm test` — 745/745 pass, including updated/added unit tests for
  `detectContentSourceKind` covering the `api.aem.live`-only match and the
  `adobeaemcloud`/`franklin.delivery` fallback to `byom`.
- `npm run lint` — clean.

## Test URL

https://fix-source-detection--helix-tools-website--adobe.aem.page/bot/setup?org=dummy&site=dummy&url=https%3A%2F%2Fauthor-p130360-e1272151.adobeaemcloud.com%2Fbin%2Ffranklin.delivery%2Fadobe-rnd%2Faem-boilerplate-xwalk%2Fmain#2

Open the link, land on the Content step: the type now shows "Other (bring
your own markup)" with the real franklin.delivery URL editable in the field,
instead of "AEM" with the URL replaced by a synthetic `api.aem.live` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)