### PR TITLE
feat: localize asset sourcing portal

### DIFF
--- a/tests/tools/asset-sourcing-portal/api.test.js
+++ b/tests/tools/asset-sourcing-portal/api.test.js
@@ -1,8 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  ForceRotateRequiredError,
+  ForcePasswordRotationRequiredError,
   PortalApi,
+  PortalApiError,
   SessionExpiredError,
 } from '../../../tools/asset-sourcing-portal/api.js';
 
@@ -24,50 +25,74 @@ describe('portal API client', () => {
       return new Response(JSON.stringify({
         sessionToken: 'memory-only-token',
         expiresAt: Math.floor(Date.now() / 1000) + 3600,
+        username: 'vendor-user',
+        vendor: { vendorId: 'vendor-one', name: 'Vendor One' },
         metadataSchema: { editable: [], required: [], prepopulated: {} },
       }), { status: 200, headers: { 'content-type': 'application/json' } });
     });
-    await api.createSession('account', 'secret-key');
+    await api.createSession(' Vendor.User ', ' secret password ');
     assert.equal(
       request.url,
       'https://api.example.com/api/upload/v1/session?org=customer%2Fone',
     );
     assert.match(request.options.headers.Authorization, /^Basic /);
+    assert.equal(
+      atob(request.options.headers.Authorization.replace('Basic ', '')),
+      'vendor.user: secret password ',
+    );
     assert.equal(api.getSessionToken(), 'memory-only-token');
     assert.equal(window.sessionStorage.getItem('asp_auth'), null);
     assert.equal(window.localStorage.getItem('asp_auth'), null);
   });
 
-  it('surfaces forced rotation without creating a session', async () => {
+  it('surfaces forced password rotation without creating a session', async () => {
     const api = new PortalApi(config, async () => new Response(JSON.stringify({
-      code: 'FORCE_ROTATE_REQUIRED',
+      code: 'FORCE_PASSWORD_ROTATION_REQUIRED',
       error: 'Rotate now',
     }), { status: 401 }));
     await assert.rejects(
       () => api.createSession('account', 'old-key'),
-      ForceRotateRequiredError,
+      ForcePasswordRotationRequiredError,
     );
     assert.equal(api.getSessionToken(), '');
   });
 
-  it('uses the configured organization for public branding and key rotation', async () => {
+  it('uses the configured organization for public branding and password rotation', async () => {
     const requests = [];
     const api = new PortalApi(config, async (url) => {
       requests.push(url);
       if (url.includes('/portal-branding/login?')) {
         return new Response('{}', { status: 200 });
       }
-      return new Response(JSON.stringify({ apiKey: 'replacement-key' }), {
+      return new Response(JSON.stringify({
+        password: 'replacement-password',
+        passwordId: 'password-two',
+      }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
     });
     await api.getLoginBranding();
-    await api.rotateKey('shared-account', 'current-key');
+    await api.rotatePassword('shared-user', 'current-password');
     assert.deepEqual(requests, [
       'https://api.example.com/api/upload/v1/portal-branding/login?org=customer%2Fone',
-      'https://api.example.com/api/upload/v1/account/rotate-key?org=customer%2Fone',
+      'https://api.example.com/api/upload/v1/account/rotate-password?org=customer%2Fone',
     ]);
+  });
+
+  it('preserves structured backend error codes and parameters', async () => {
+    const api = new PortalApi(config, async () => new Response(JSON.stringify({
+      code: 'FILE_TOO_LARGE',
+      error: 'Raw backend text must not be displayed',
+      params: { maxFileBytes: 42 },
+    }), { status: 413 }));
+    api.setSession({ sessionToken: 'token', expiresAt: Date.now() + 10000 });
+    await assert.rejects(
+      () => api.startBatch({}),
+      (error) => error instanceof PortalApiError
+        && error.code === 'FILE_TOO_LARGE'
+        && error.params.maxFileBytes === 42,
+    );
   });
 
   it('fails closed and clears a rejected session', async () => {
@@ -108,11 +133,11 @@ describe('portal API client', () => {
     );
     assert.throws(
       () => api.validateUploadUri('https://evil.example/upload'),
-      /unapproved/,
+      (error) => error instanceof PortalApiError && error.code === 'UPLOAD_FAILED',
     );
     assert.throws(
       () => api.validateUploadUri('http://author.example.adobeaemcloud.com/upload'),
-      /unapproved/,
+      (error) => error instanceof PortalApiError && error.code === 'UPLOAD_FAILED',
     );
   });
 
@@ -128,7 +153,7 @@ describe('portal API client', () => {
     );
     assert.throws(
       () => api.validateUploadUri('http://localhost:3001/mock-upload'),
-      /unapproved/,
+      (error) => error instanceof PortalApiError && error.code === 'UPLOAD_FAILED',
     );
   });
 });

--- a/tests/tools/asset-sourcing-portal/config.test.js
+++ b/tests/tools/asset-sourcing-portal/config.test.js
@@ -21,11 +21,13 @@ describe('portal configuration', () => {
       apiBaseUrl: 'https://api.example.com',
       org: 'customer-one',
       tenantSlug: 'customer-one',
+      locale: 'fr',
       uploadHostSuffixes: ['.adobeaemcloud.com'],
       branding: { title: '<Customer>', logoSrc: '/icons/adobe.svg' },
     }, 'https://portal.example.com/?org=ignored');
     assert.equal(config.branding.title, '<Customer>');
     assert.equal(config.org, 'customer-one');
+    assert.equal(config.locale, 'fr');
     assert.deepEqual(config.uploadHostSuffixes, ['.adobeaemcloud.com']);
   });
 
@@ -52,6 +54,14 @@ describe('portal configuration', () => {
       apiBaseUrl: 'https://api.example.com',
       org: 'customer@internal',
     }), /without a suffix/);
+  });
+
+  it('rejects unsupported configured locales', () => {
+    assert.throws(() => validatePortalConfig({
+      apiBaseUrl: 'https://api.example.com',
+      org: 'customer',
+      locale: 'xx',
+    }), /supported portal locale/);
   });
 
   it('rejects cross-origin logos and malformed upload suffixes', () => {

--- a/tests/tools/asset-sourcing-portal/localization.test.js
+++ b/tests/tools/asset-sourcing-portal/localization.test.js
@@ -1,0 +1,197 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CatalogLoader,
+  createI18n,
+  formatPattern,
+  localeStorageKey,
+  localizeError,
+  normalizeLocale,
+  persistLocale,
+  replaceUrlLocale,
+  resolveInitialLocale,
+  resolveMetadataLabel,
+  resolveVendorLocale,
+} from '../../../tools/asset-sourcing-portal/localization.js';
+
+describe('portal localization', () => {
+  it('resolves URL, org-scoped persistence, configured, page, and browser locales in order', () => {
+    const storage = new Map([[localeStorageKey('customer'), 'fr']]);
+    const resolve = (pageUrl, configuredLocale = 'de') => resolveInitialLocale({
+      pageUrl,
+      org: 'customer',
+      configuredLocale,
+      documentLocale: 'es',
+      browserLocales: ['hi'],
+      storage: { getItem: (key) => storage.get(key) ?? null },
+    });
+    assert.deepEqual(resolve('https://portal.example/?org=customer&lang=ar'), {
+      locale: 'ar',
+      source: 'url',
+    });
+    assert.deepEqual(resolve('https://portal.example/?org=customer'), {
+      locale: 'fr',
+      source: 'persisted',
+    });
+    storage.clear();
+    assert.deepEqual(resolve('https://portal.example/?org=customer'), {
+      locale: 'de',
+      source: 'configured',
+    });
+    assert.equal(normalizeLocale('pt-PT'), 'pt-BR');
+    assert.equal(normalizeLocale('zh-CN'), 'zh-Hans');
+  });
+
+  it('uses vendor defaults unless an explicit supported preference exists', () => {
+    const config = { supportedLocales: ['en', 'fr', 'ar'], defaultLocale: 'fr' };
+    assert.equal(resolveVendorLocale('ar', 'url', config), 'ar');
+    assert.equal(resolveVendorLocale('hi', 'url', config), 'fr');
+    assert.equal(resolveVendorLocale('ar', 'browser', config), 'fr');
+    assert.equal(resolveVendorLocale('de', 'persisted', {
+      supportedLocales: ['en'],
+      defaultLocale: 'de',
+    }), 'de');
+  });
+
+  it('resolves localized metadata labels without changing values', () => {
+    const field = {
+      id: 'dc:title',
+      label: 'Configured title',
+      labelByLocale: { en: 'Title', fr: 'Titre', 'pt-BR': 'Título' },
+    };
+    assert.equal(resolveMetadataLabel(field, 'fr'), 'Titre');
+    assert.equal(resolveMetadataLabel(field, 'pt-BR'), 'Título');
+    assert.equal(resolveMetadataLabel(field, 'de'), 'Title');
+    assert.equal(resolveMetadataLabel({ id: 'campaign' }, 'hi'), 'campaign');
+  });
+
+  it('formats ICU plurals, localized numbers, and dates', () => {
+    assert.equal(
+      formatPattern(
+        '{count, plural, one {# file} other {# files}}',
+        { count: 2 },
+        'fr',
+      ),
+      '2 files',
+    );
+    const i18n = createI18n('hi', {
+      count: '{count, plural, one {# फ़ाइल} other {# फ़ाइलें}}',
+      limit: '{limit, number}',
+    });
+    assert.equal(i18n.t('count', { count: 3 }), '3 फ़ाइलें');
+    assert.equal(i18n.t('limit', { limit: 1000 }), '1,000');
+    assert.equal(createI18n('ar', {}).direction, 'rtl');
+  });
+
+  it('persists only the org locale and preserves URL organization parameters', () => {
+    const stored = new Map();
+    persistLocale('fr', 'customer/one', {
+      setItem: (key, value) => stored.set(key, value),
+    });
+    assert.deepEqual([...stored], [['asp.locale.customer/one', 'fr']]);
+    const result = replaceUrlLocale(
+      'hi',
+      'https://portal.example/index.html?org=customer%2Fone&campaign=spring',
+      { state: null, replaceState: () => {} },
+    );
+    const url = new URL(result);
+    assert.equal(url.searchParams.get('org'), 'customer/one');
+    assert.equal(url.searchParams.get('campaign'), 'spring');
+    assert.equal(url.searchParams.get('lang'), 'hi');
+  });
+
+  it('maps structured errors to localized catalog messages', () => {
+    const i18n = createI18n('fr', {
+      'error.auth.invalidPassword': 'Mot de passe non valide',
+      'error.upload.fileTooLarge': 'Maximum {maxFileBytes, number}',
+      'error.generic': 'Erreur générique',
+    });
+    assert.equal(localizeError(i18n, {
+      code: 'INVALID_PASSWORD',
+      error: 'Raw backend English',
+    }), 'Mot de passe non valide');
+    assert.equal(localizeError(i18n, {
+      code: 'FILE_TOO_LARGE',
+      params: { maxFileBytes: 1000 },
+    }), 'Maximum 1 000');
+  });
+
+  it('loads one selected hashed catalog and retries English only after failure', async () => {
+    const requests = [];
+    const responses = new Map([
+      ['https://api.example/i18n/manifest.json', {
+        catalogs: {
+          en: { url: './en.hash.json', sha256: 'one' },
+          fr: { url: './fr.hash.json', sha256: 'two' },
+        },
+      }],
+      ['https://api.example/i18n/fr.hash.json', { hello: 'Bonjour' }],
+      ['https://api.example/i18n/en.hash.json', { hello: 'Hello' }],
+    ]);
+    const fetchImpl = async (url) => {
+      requests.push(url);
+      return new Response(JSON.stringify(responses.get(url)), {
+        status: responses.has(url) ? 200 : 404,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+    const loader = new CatalogLoader(
+      'https://api.example/i18n/manifest.json',
+      fetchImpl,
+    );
+    const french = await loader.load('fr');
+    assert.equal(french.t('hello'), 'Bonjour');
+    assert.deepEqual(requests, [
+      'https://api.example/i18n/manifest.json',
+      'https://api.example/i18n/fr.hash.json',
+    ]);
+
+    responses.delete('https://api.example/i18n/fr.hash.json');
+    const retryLoader = new CatalogLoader(
+      'https://api.example/i18n/manifest.json',
+      fetchImpl,
+    );
+    requests.length = 0;
+    const fallback = await retryLoader.load('fr');
+    assert.equal(fallback.locale, 'en');
+    assert.equal(fallback.t('hello'), 'Hello');
+    assert.deepEqual(requests, [
+      'https://api.example/i18n/manifest.json',
+      'https://api.example/i18n/fr.hash.json',
+      'https://api.example/i18n/en.hash.json',
+    ]);
+  });
+
+  it('resolves hashed catalogs relative to the final manifest URL', async () => {
+    const requests = [];
+    const fetchImpl = async (url) => {
+      requests.push(url);
+      if (url === 'https://api.example/i18n/manifest.json') {
+        return {
+          ok: true,
+          url: 'https://cdn.example/catalogs/manifest.json',
+          json: async () => ({
+            catalogs: {
+              fr: { url: './fr.hash.json', sha256: 'hash' },
+              en: { url: './en.hash.json', sha256: 'hash' },
+            },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        url,
+        json: async () => ({ hello: 'Bonjour' }),
+      };
+    };
+    const loader = new CatalogLoader(
+      'https://api.example/i18n/manifest.json',
+      fetchImpl,
+    );
+    assert.equal((await loader.load('fr')).t('hello'), 'Bonjour');
+    assert.deepEqual(requests, [
+      'https://api.example/i18n/manifest.json',
+      'https://cdn.example/catalogs/fr.hash.json',
+    ]);
+  });
+});

--- a/tests/tools/asset-sourcing-portal/static.test.js
+++ b/tests/tools/asset-sourcing-portal/static.test.js
@@ -46,9 +46,24 @@ describe('portal static shell', () => {
   });
 
   it('does not add unsafe DOM parsing or session-token persistence', async () => {
-    const source = await readToolFile('asset-sourcing-portal.js');
+    const [source, localization] = await Promise.all([
+      readToolFile('asset-sourcing-portal.js'),
+      readToolFile('localization.js'),
+    ]);
     assert.doesNotMatch(source, /innerHTML|insertAdjacentHTML/);
     assert.doesNotMatch(source, /(?:session|local)Storage\.setItem/);
     assert.doesNotMatch(source, /\.style\./);
+    assert.match(localization, /asp\.locale\./);
+    assert.doesNotMatch(localization, /sessionToken|passwordId|currentPassword/);
+  });
+
+  it('uses backend catalogs without checking translated strings into EDS', async () => {
+    const [source, localization] = await Promise.all([
+      readToolFile('asset-sourcing-portal.js'),
+      readToolFile('localization.js'),
+    ]);
+    assert.match(source, /getI18nManifestUrl/);
+    assert.match(localization, /manifest\.catalogs\[locale\]/);
+    assert.doesNotMatch(localization, /"login\.lead"/);
   });
 });

--- a/tests/tools/asset-sourcing-portal/ui-localization.test.js
+++ b/tests/tools/asset-sourcing-portal/ui-localization.test.js
@@ -1,0 +1,241 @@
+import {
+  before, describe, it, mock,
+} from 'node:test';
+import assert from 'node:assert/strict';
+
+const readyPromises = [];
+mock.module('../../../scripts/scripts.js', {
+  namedExports: {
+    registerToolReady: (...promises) => {
+      readyPromises.push(...promises);
+    },
+  },
+});
+
+const catalogs = {
+  fr: {
+    'app.language.label': 'Langue',
+    'app.title.login': 'Portail de chargement',
+    'app.title.upload': 'Charger des ressources',
+    'login.lead': 'Connexion en français',
+    'login.form.username.label': 'Nom d’utilisateur',
+    'login.form.username.placeholder': 'Utilisateur',
+    'login.form.password.label': 'Mot de passe',
+    'login.form.password.placeholder': 'Mot de passe',
+    'login.continue': 'Continuer vers le chargement',
+    'upload.metadata.title': 'Métadonnées',
+    'upload.metadata.appliesToBatch': 'Pour chaque fichier',
+    'upload.metadata.select': '— Sélectionner —',
+    'upload.batch.label': 'Lot {number, number}',
+    'upload.batch.accessibleLabel': 'Lot {number, number}',
+    'upload.batch.add': 'Ajouter un lot',
+    'upload.dropZone.label': 'Charger des fichiers',
+    'upload.dropZone.prompt': 'Déposer les fichiers ici',
+    'upload.dropZone.browse': 'Parcourir les fichiers',
+    'upload.dropZone.selectFolder': 'Sélectionner un dossier',
+    'upload.pathPolicy.preserve': 'Structure conservée',
+    'upload.signedInAs': 'Connecté en tant que {username}',
+    'user.menu.label': 'Menu utilisateur',
+    'user.menu.signedInAs': 'Connecté en tant que {username}',
+    'user.menu.signOut': 'Se déconnecter',
+  },
+  hi: {
+    'app.language.label': 'भाषा',
+    'app.title.login': 'अपलोड पोर्टल',
+    'login.lead': 'हिन्दी में साइन इन करें',
+    'login.form.username.label': 'उपयोगकर्ता नाम',
+    'login.form.username.placeholder': 'उपयोगकर्ता',
+    'login.form.password.label': 'पासवर्ड',
+    'login.form.password.placeholder': 'पासवर्ड',
+    'login.continue': 'अपलोड करने के लिए आगे बढ़ें',
+  },
+  ar: {
+    'app.language.label': 'اللغة',
+    'app.title.login': 'بوابة التحميل',
+    'app.title.upload': 'تحميل الأصول',
+    'login.lead': 'تسجيل الدخول بالعربية',
+    'login.form.username.label': 'اسم المستخدم',
+    'login.form.username.placeholder': 'اسم المستخدم',
+    'login.form.password.label': 'كلمة المرور',
+    'login.form.password.placeholder': 'كلمة المرور',
+    'login.continue': 'المتابعة إلى التحميل',
+    'upload.metadata.title': 'بيانات التعريف',
+    'upload.metadata.appliesToBatch': 'لكل ملف',
+    'upload.metadata.select': '— تحديد —',
+    'upload.batch.label': 'الدفعة {number, number}',
+    'upload.batch.accessibleLabel': 'دفعة {number, number}',
+    'upload.batch.add': 'إضافة دفعة',
+    'upload.dropZone.label': 'تحميل الملفات',
+    'upload.dropZone.prompt': 'أفلِت الملفات هنا',
+    'upload.dropZone.browse': 'استعراض الملفات',
+    'upload.dropZone.selectFolder': 'تحديد مجلد',
+    'upload.pathPolicy.preserve': 'تم الاحتفاظ بالبنية',
+    'upload.signedInAs': 'تم تسجيل الدخول باسم {username}',
+    'user.menu.label': 'قائمة المستخدم',
+    'user.menu.signedInAs': 'تم تسجيل الدخول باسم {username}',
+    'user.menu.signOut': 'تسجيل الخروج',
+  },
+  en: {
+    'app.language.label': 'Language',
+    'app.title.login': 'Upload portal',
+    'login.lead': 'Sign in',
+    'login.form.username.label': 'Username',
+    'login.form.password.label': 'Password',
+    'login.continue': 'Continue',
+  },
+};
+
+function portalMarkup() {
+  document.body.innerHTML = `
+    <main><div id="asp-portal-shell" class="asp-portal-shell">
+      <section id="asp-portal-header"><div id="asp-portal-brand">
+        <div id="asp-portal-logo"><img alt=""></div>
+        <div id="asp-portal-title"><h1></h1></div>
+        <div><label id="asp-language-label" for="asp-language"></label>
+          <select id="asp-language"></select>
+          <p id="asp-language-message" hidden></p></div>
+      </div><div id="asp-portal-banner"></div></section>
+      <section><div id="asp-portal-signin">
+        <p class="login-lead"></p><p id="asp-login-message" hidden></p>
+        <form id="asp-login-form">
+          <label id="asp-username-label" for="username"></label>
+          <input id="username" required>
+          <label id="asp-password-label" for="password"></label>
+          <input id="password" type="password" required>
+          <button id="asp-login-button"></button>
+        </form>
+      </div><div id="asp-upload-view" hidden></div>
+      <div id="asp-confirmation-view" hidden></div></section>
+      <div id="asp-modal-root"></div>
+    </div></main>`;
+}
+
+async function waitFor(predicate) {
+  for (let attempts = 0; attempts < 50; attempts += 1) {
+    if (predicate()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+  }
+  assert.fail('Timed out waiting for localized portal state');
+}
+
+describe('localized portal UI', () => {
+  const catalogRequests = [];
+
+  before(async () => {
+    portalMarkup();
+    window.history.replaceState(null, '', '/?org=customer&lang=fr');
+    const fetchStub = async (url, options = {}) => {
+      const requestUrl = String(url);
+      if (requestUrl === './portal-config.json') {
+        return new Response(JSON.stringify({
+          apiBaseUrl: 'https://api.example.com',
+          org: '',
+          locale: 'en',
+          uploadHostSuffixes: ['.adobeaemcloud.com'],
+          branding: { title: 'Configured brand', logoSrc: '/icons/adobe.svg' },
+        }));
+      }
+      if (requestUrl.endsWith('/i18n/manifest.json')) {
+        return new Response(JSON.stringify({
+          defaultLocale: 'en',
+          catalogs: Object.fromEntries(Object.keys(catalogs).map((locale) => [
+            locale,
+            { url: `./${locale}.hash.json`, sha256: locale },
+          ])),
+        }));
+      }
+      const catalogLocale = requestUrl.match(/\/(en|fr|hi|ar)\.hash\.json$/)?.[1];
+      if (catalogLocale) {
+        catalogRequests.push(catalogLocale);
+        return new Response(JSON.stringify(catalogs[catalogLocale]));
+      }
+      if (requestUrl.includes('/portal-branding/login?')) return new Response('{}');
+      if (requestUrl.includes('/session?') && options.method === 'POST') {
+        return new Response(JSON.stringify({
+          sessionToken: 'memory-token',
+          expiresAt: Date.now() + 60000,
+          username: 'vendor.user',
+          vendor: { vendorId: 'vendor-one', name: 'Vendor Display Name' },
+          metadataSchema: {
+            editable: [{
+              id: 'campaignTitle',
+              label: 'Campaign title',
+              labelByLocale: { en: 'Campaign title', fr: 'Titre de campagne', ar: 'عنوان الحملة' },
+              type: 'text',
+            }],
+            required: [],
+            prepopulated: {},
+          },
+          portalLocalization: {
+            supportedLocales: ['en', 'fr', 'hi', 'ar'],
+            defaultLocale: 'fr',
+          },
+          uploadPathPolicy: { mode: 'preserve' },
+          limits: { maxFileBytes: 1000, maxBatch: 10 },
+        }), { headers: { 'content-type': 'application/json' } });
+      }
+      throw new Error(`Unexpected request: ${requestUrl}`);
+    };
+    global.fetch = fetchStub;
+    window.fetch = fetchStub;
+    await import('../../../tools/asset-sourcing-portal/asset-sourcing-portal.js');
+    assert.equal(readyPromises.length, 1);
+    await Promise.all(readyPromises);
+    assert.equal(
+      document.documentElement.lang,
+      'fr',
+      document.getElementById('asp-login-message').textContent,
+    );
+  });
+
+  it('preserves credentials while rendering Hindi and Arabic RTL', async () => {
+    const username = document.getElementById('username');
+    const password = document.getElementById('password');
+    const selector = document.getElementById('asp-language');
+    username.value = 'remember-user';
+    password.value = 'remember-password';
+
+    selector.value = 'hi';
+    selector.dispatchEvent(new window.Event('change'));
+    await waitFor(() => document.documentElement.lang === 'hi');
+    assert.equal(document.getElementById('asp-username-label').textContent, 'उपयोगकर्ता नाम');
+    assert.equal(username.value, 'remember-user');
+    assert.equal(password.value, 'remember-password');
+
+    selector.value = 'ar';
+    selector.dispatchEvent(new window.Event('change'));
+    await waitFor(() => document.documentElement.lang === 'ar');
+    assert.equal(document.documentElement.dir, 'rtl');
+    assert.equal(username.value, 'remember-user');
+    assert.equal(password.dir, 'ltr');
+  });
+
+  it('keeps French metadata state across authenticated locale changes', async () => {
+    const selector = document.getElementById('asp-language');
+    selector.value = 'fr';
+    selector.dispatchEvent(new window.Event('change'));
+    await waitFor(() => document.documentElement.lang === 'fr');
+    document.getElementById('asp-login-form').dispatchEvent(
+      new window.Event('submit', { bubbles: true, cancelable: true }),
+    );
+    await waitFor(() => !document.getElementById('asp-upload-view').hidden);
+
+    const label = [...document.querySelectorAll('label')]
+      .find((item) => item.textContent === 'Titre de campagne');
+    assert.ok(label);
+    const input = document.getElementById(label.htmlFor);
+    input.value = 'Unchanged metadata';
+    input.dispatchEvent(new window.Event('input', { bubbles: true }));
+
+    selector.value = 'ar';
+    selector.dispatchEvent(new window.Event('change'));
+    await waitFor(() => document.documentElement.lang === 'ar');
+    assert.equal(document.getElementById(label.htmlFor).value, 'Unchanged metadata');
+    assert.ok([...document.querySelectorAll('label')]
+      .some((item) => item.textContent === 'عنوان الحملة'));
+    assert.deepEqual(catalogRequests, ['fr', 'hi', 'ar']);
+    document.querySelector('.account-menu-trigger').click();
+    [...document.querySelectorAll('.account-menu-item')].at(-1).click();
+  });
+});

--- a/tools/asset-sourcing-portal/README.md
+++ b/tools/asset-sourcing-portal/README.md
@@ -8,9 +8,17 @@ This tool is an optional customer-hosted alternative to the generic React Spectr
 portal bundled with the backend. Both implementations use the same upload API and
 authentication contract; deploying this EDS tool does not retire the generic portal.
 
-Login, upload, and confirmation are states in one document. The session JWT and upload
-files exist only in JavaScript memory; refreshing or closing the page returns the user
-to login. Raw API-key fields are cleared after session or replacement-key minting.
+Authentication uses HTTP Basic with the backend-issued `username` and opaque
+`password`. Vendor display names remain presentation data and are never used as login
+identifiers. Usernames are trimmed and lowercased; passwords are sent byte-for-byte
+without trimming. Self-service changes call
+`/api/upload/v1/account/rotate-password?org=<organization ID>` and consume the returned
+`password` and `passwordId`; the generated password is shown only once.
+
+Login, upload, and confirmation are states in one document. The session JWT, password,
+metadata form state, and selected upload files exist only in JavaScript memory;
+refreshing or closing the page returns the user to login. Raw password fields are
+cleared after session or replacement-password minting.
 
 The checked-in configuration uses the branded stage API. Before pointing this tool at
 the production API, update both `portal-config.json` and the `connect-src` directive in
@@ -30,6 +38,9 @@ exact-origin CORS configuration.
      supplied in the page URL.
    - `tenantSlug`: a public deployment label. It is not a credential or an
      authorization boundary.
+   - `locale`: optional EDS deployment default. Supported values are `en`, `fr`,
+     `de`, `es`, `pt-BR`, `ja`, `ko`, `zh-Hans`, `ar`, and `hi`. URL `lang`
+     and the organization-scoped browser selection take precedence.
    - `uploadHostSuffixes`: only the HTTPS host suffixes the API may return for
      direct multipart PUTs. Keep this list as narrow as the customer's AEM
      deployment permits.
@@ -50,11 +61,11 @@ https://example.com/tools/asset-sourcing-portal/index.html?org=0123456789ABCDEF
 ```
 
 When neither the fork configuration nor the URL supplies an organization, the portal
-fails closed, disables sign-in, and shows a configuration error. The account name is
-never used to infer tenancy.
+fails closed, disables sign-in, and shows a configuration error. The username is never
+used to infer tenancy.
 
 The short organization ID is a public routing identifier, not an IMS credential. Do not
-put API keys, session tokens, Adobe IMS credentials, AEM credentials, intake paths,
+put passwords, session tokens, Adobe IMS credentials, AEM credentials, intake paths,
 or other secrets in `portal-config.json` or any EDS source file.
 
 ## Content Security Policy
@@ -67,6 +78,25 @@ only enforced when delivered as a response header.
 
 Authenticated backend banner URLs must resolve to the configured API origin. Legacy
 public HTTPS banner URLs can be displayed without credentials.
+
+## Localization
+
+The portal fetches `/api/upload/v1/i18n/manifest.json` from the configured API and then
+loads only the selected hashed locale catalog. If that catalog cannot be loaded, it
+retries the English catalog. Translation catalogs remain backend-owned and must not be
+copied into this repository.
+
+Deploy the backend manifest, hashed catalogs, canonical username/password endpoints,
+and session `portalLocalization`/metadata `labelByLocale` fields before enabling this
+frontend against an environment. The API origin must also allow the deployed EDS
+origins through its exact-origin CORS configuration.
+
+The selector stores only the locale under an organization-scoped `asp.locale.<org>`
+browser key and updates `lang` without removing `org` or other URL parameters. After
+sign-in, the vendor's `portalLocalization` limits available locales and supplies the
+default when there was no explicit URL or persisted selection. Localized metadata
+labels come from each field's `labelByLocale`; field IDs, option values, submitted
+metadata, filenames, paths, and branding remain unchanged.
 
 ## Local testing
 

--- a/tools/asset-sourcing-portal/api.js
+++ b/tools/asset-sourcing-portal/api.js
@@ -1,28 +1,42 @@
 /* eslint-disable max-classes-per-file */
-export class ForceRotateRequiredError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = 'ForceRotateRequiredError';
+export class ForcePasswordRotationRequiredError extends Error {
+  constructor(response) {
+    super(response.error);
+    this.response = response;
+    this.code = response.code;
+    this.params = response.params;
+    this.name = 'ForcePasswordRotationRequiredError';
   }
 }
 
-export class LoginLockedError extends Error {
-  constructor(message, retryAfterSeconds) {
-    super(message);
+export class PortalApiError extends Error {
+  constructor(response) {
+    super(response.error);
+    this.response = response;
+    this.code = response.code;
+    this.params = response.params;
+    this.name = 'PortalApiError';
+  }
+}
+
+export class LoginLockedError extends PortalApiError {
+  constructor(response, retryAfterSeconds) {
+    super(response);
     this.name = 'LoginLockedError';
     this.retryAfterSeconds = retryAfterSeconds;
   }
 }
 
-export class SessionExpiredError extends Error {
-  constructor(message = 'Your session has expired. Please sign in again.') {
-    super(message);
+export class SessionExpiredError extends PortalApiError {
+  constructor(response = { code: 'INVALID_SESSION', error: '' }) {
+    super(response);
     this.name = 'SessionExpiredError';
   }
 }
 
-function basicAuthorization(accountName, apiKey) {
-  const bytes = new TextEncoder().encode(`${accountName}:${apiKey}`);
+function basicAuthorization(username, password) {
+  const normalizedUsername = username.trim().toLowerCase();
+  const bytes = new TextEncoder().encode(`${normalizedUsername}:${password}`);
   let binary = '';
   bytes.forEach((byte) => {
     binary += String.fromCharCode(byte);
@@ -30,18 +44,18 @@ function basicAuthorization(accountName, apiKey) {
   return `Basic ${btoa(binary)}`;
 }
 
-async function errorDetails(response, fallback) {
+async function errorDetails(response, fallbackCode) {
   const text = (await response.text()).slice(0, 500);
   try {
     const payload = JSON.parse(text);
     return {
-      message: typeof payload.error === 'string' ? payload.error : fallback,
-      code: typeof payload.code === 'string' ? payload.code : undefined,
-      retryAfterSeconds: Number.isFinite(payload.retryAfterSeconds)
-        ? payload.retryAfterSeconds : undefined,
+      error: typeof payload.error === 'string' ? payload.error : '',
+      code: typeof payload.code === 'string' ? payload.code : fallbackCode,
+      params: payload.params && typeof payload.params === 'object' && !Array.isArray(payload.params)
+        ? payload.params : undefined,
     };
   } catch {
-    return { message: text || fallback };
+    return { error: '', code: fallbackCode };
   }
 }
 
@@ -59,6 +73,10 @@ export class PortalApi {
     this.fetchImpl = fetchImpl;
     this.sessionToken = '';
     this.sessionExpiresAt = 0;
+  }
+
+  getI18nManifestUrl() {
+    return `${this.apiBase}/i18n/manifest.json`;
   }
 
   clearSession() {
@@ -90,9 +108,7 @@ export class PortalApi {
   async getLoginBranding() {
     const response = await this.fetchImpl(
       this.tenantUrl('/portal-branding/login'),
-      {
-        headers: { Accept: 'application/json' },
-      },
+      { headers: { Accept: 'application/json' } },
     );
     if (!response.ok) return {};
     const branding = await response.json();
@@ -100,53 +116,57 @@ export class PortalApi {
       ? branding : {};
   }
 
-  async createSession(accountName, apiKey) {
+  async createSession(username, password) {
     const response = await this.fetchImpl(this.tenantUrl('/session'), {
       method: 'POST',
       headers: {
         Accept: 'application/json',
-        Authorization: basicAuthorization(accountName, apiKey),
+        Authorization: basicAuthorization(username, password),
       },
     });
     if (!response.ok) {
-      const details = await errorDetails(response, 'Sign-in failed.');
-      if (details.code === 'FORCE_ROTATE_REQUIRED') {
-        throw new ForceRotateRequiredError(details.message);
+      const details = await errorDetails(response, 'SERVICE_UNAVAILABLE');
+      if (details.code === 'FORCE_PASSWORD_ROTATION_REQUIRED') {
+        throw new ForcePasswordRotationRequiredError(details);
       }
       if (details.code === 'LOGIN_LOCKED') {
-        throw new LoginLockedError(details.message, details.retryAfterSeconds);
+        const retryAfterSeconds = Number.isFinite(details.params?.retryAfterSeconds)
+          ? details.params.retryAfterSeconds : undefined;
+        throw new LoginLockedError(details, retryAfterSeconds);
       }
-      throw new Error(details.message);
+      throw new PortalApiError(details);
     }
     const session = await response.json();
     if (!session || typeof session.sessionToken !== 'string'
-      || !Number.isFinite(session.expiresAt) || typeof session.metadataSchema !== 'object') {
-      throw new Error('The service returned an invalid session response.');
+      || !Number.isFinite(session.expiresAt) || typeof session.username !== 'string'
+      || !session.vendor || typeof session.vendor.name !== 'string'
+      || typeof session.metadataSchema !== 'object') {
+      throw new PortalApiError({ code: 'SERVICE_UNAVAILABLE', error: '' });
     }
     this.setSession(session);
     return session;
   }
 
-  async rotateKey(accountName, currentApiKey, graceHours = 0) {
+  async rotatePassword(username, currentPassword, graceHours = 0) {
     const response = await this.fetchImpl(
-      this.tenantUrl('/account/rotate-key'),
+      this.tenantUrl('/account/rotate-password'),
       {
         method: 'POST',
         headers: {
           Accept: 'application/json',
-          Authorization: basicAuthorization(accountName, currentApiKey),
+          Authorization: basicAuthorization(username, currentPassword),
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ graceHours }),
       },
     );
     if (!response.ok) {
-      const details = await errorDetails(response, 'Key rotation failed.');
-      throw new Error(details.message);
+      throw new PortalApiError(await errorDetails(response, 'SERVICE_UNAVAILABLE'));
     }
     const result = await response.json();
-    if (!result || typeof result.apiKey !== 'string') {
-      throw new Error('The service returned an invalid key rotation response.');
+    if (!result || typeof result.password !== 'string'
+      || typeof result.passwordId !== 'string') {
+      throw new PortalApiError({ code: 'SERVICE_UNAVAILABLE', error: '' });
     }
     return result;
   }
@@ -157,17 +177,17 @@ export class PortalApi {
       ...options,
       headers: {
         Accept: 'application/json',
-        Authorization: `Bearer ${this.sessionToken}`,
+        Authorization: ['Bearer', this.sessionToken].join(' '),
         ...options.headers,
       },
     });
     if (!response.ok) {
-      const details = await errorDetails(response, 'The request failed.');
+      const details = await errorDetails(response, 'SERVICE_UNAVAILABLE');
       if (response.status === 401) {
         this.clearSession();
-        throw new SessionExpiredError(details.message);
+        throw new SessionExpiredError(details);
       }
-      throw new Error(details.message);
+      throw new PortalApiError(details);
     }
     return response;
   }
@@ -231,7 +251,7 @@ export class PortalApi {
     try {
       url = new URL(value);
     } catch {
-      throw new Error('The service returned an invalid upload URL.');
+      throw new PortalApiError({ code: 'UPLOAD_FAILED', error: '' });
     }
     const hostname = url.hostname.toLowerCase();
     const allowedStorage = this.uploadHostSuffixes.some((suffix) => hostname.endsWith(suffix));
@@ -240,7 +260,7 @@ export class PortalApi {
       && ['localhost', '127.0.0.1', '[::1]'].includes(hostname);
     if ((url.protocol !== 'https:' && !localApiHttp)
       || (url.origin !== this.apiOrigin && !allowedStorage)) {
-      throw new Error('The service returned an unapproved upload destination.');
+      throw new PortalApiError({ code: 'UPLOAD_FAILED', error: '' });
     }
     return url.href;
   }
@@ -259,9 +279,11 @@ export class PortalApi {
       };
       request.onload = () => {
         if (request.status >= 200 && request.status < 300) resolve();
-        else reject(new Error(`Upload storage returned ${request.status}.`));
+        else reject(new PortalApiError({ code: 'UPLOAD_FAILED', error: '' }));
       };
-      request.onerror = () => reject(new Error('A network error interrupted the upload.'));
+      request.onerror = () => reject(
+        new PortalApiError({ code: 'SERVICE_UNAVAILABLE', error: '' }),
+      );
       request.send(chunk);
     });
   }
@@ -269,7 +291,7 @@ export class PortalApi {
   async uploadFileBlocks(file, initiation, onProgress) {
     if (!Array.isArray(initiation.uploadURIs) || !initiation.uploadURIs.length
       || !Number.isFinite(initiation.maxPartSize) || !Number.isFinite(initiation.minPartSize)) {
-      throw new Error('The service returned invalid multipart upload instructions.');
+      throw new PortalApiError({ code: 'UPLOAD_FAILED', error: '' });
     }
     const { uploadURIs, maxPartSize, minPartSize } = initiation;
     if (uploadURIs.length === 1 && file.size <= maxPartSize) {
@@ -285,7 +307,6 @@ export class PortalApi {
       const start = index * partSize;
       if (start >= file.size) break;
       const chunk = file.slice(start, Math.min(start + partSize, file.size));
-      // Multipart PUTs are sequential per file; file-level concurrency is separate.
       const uploadedBeforePart = uploaded;
       // eslint-disable-next-line no-await-in-loop
       await this.putPart(uploadURIs[index], chunk, (partProgress) => {

--- a/tools/asset-sourcing-portal/asset-sourcing-portal.css
+++ b/tools/asset-sourcing-portal/asset-sourcing-portal.css
@@ -55,6 +55,11 @@
   font-size: var(--heading-size-m);
 }
 
+.asset-sourcing-portal .portal-language-selector {
+  min-width: 10rem;
+  margin-inline-start: auto;
+}
+
 .asset-sourcing-portal .asp-portal-banner:empty,
 .asset-sourcing-portal .asp-portal-footer:empty {
   display: none;
@@ -82,6 +87,11 @@
   display: block;
   margin: var(--spacing-s) 0 var(--spacing-xs);
   font-weight: 600;
+}
+
+.asset-sourcing-portal .portal-language-selector label {
+  margin-block: 0 var(--spacing-xs);
+  font-size: var(--body-size-s);
 }
 
 .asset-sourcing-portal input,
@@ -206,7 +216,7 @@
   position: absolute;
   z-index: 20;
   top: calc(100% + var(--spacing-xs));
-  right: 0;
+  inset-inline-end: 0;
   min-width: 14rem;
   border: var(--border-s) solid var(--gray-300);
   border-radius: var(--rounding-l);
@@ -228,7 +238,7 @@
   padding: var(--spacing-s);
   background: transparent;
   color: var(--color-text);
-  text-align: left;
+  text-align: start;
 }
 
 .asset-sourcing-portal .account-menu-item:hover {
@@ -251,7 +261,7 @@
 
 .asset-sourcing-portal .batch-row {
   display: grid;
-  grid-template-columns: minmax(240px, 1fr) minmax(280px, 1.1fr);
+  grid-template-columns: 1fr;
   gap: var(--spacing-l);
 }
 
@@ -363,6 +373,7 @@
 
 .asset-sourcing-portal .file-row-main {
   display: flex;
+  flex-direction: column;
   gap: var(--spacing-s);
   justify-content: space-between;
 }
@@ -370,6 +381,16 @@
 .asset-sourcing-portal .file-name {
   font-weight: 700;
   overflow-wrap: anywhere;
+}
+
+.asset-sourcing-portal .technical-value,
+.asset-sourcing-portal .file-path,
+.asset-sourcing-portal .batch-id,
+.asset-sourcing-portal .password-value,
+.asset-sourcing-portal input[type="password"],
+.asset-sourcing-portal input[id$="-upload-path"] {
+  direction: ltr;
+  unicode-bidi: isolate;
 }
 
 .asset-sourcing-portal .file-source {
@@ -432,7 +453,7 @@
   background: var(--blue-100);
 }
 
-.asset-sourcing-portal dialog.asp-key-dialog {
+.asset-sourcing-portal dialog.asp-password-dialog {
   width: min(100% - 2rem, 32rem);
   border: 0;
   border-radius: var(--rounding-xl);
@@ -440,18 +461,18 @@
   color: var(--color-text);
 }
 
-.asset-sourcing-portal dialog.asp-key-dialog::backdrop {
+.asset-sourcing-portal dialog.asp-password-dialog::backdrop {
   background: var(--transparent-black-600);
 }
 
-.asset-sourcing-portal dialog.asp-key-dialog > div {
+.asset-sourcing-portal dialog.asp-password-dialog > div {
   max-height: calc(100dvh - 4rem);
   padding: 0;
   overflow-y: auto;
 }
 
 .asset-sourcing-portal .modal-actions,
-.asset-sourcing-portal .key-reveal {
+.asset-sourcing-portal .password-reveal {
   display: flex;
   gap: var(--spacing-s);
   align-items: center;
@@ -461,24 +482,24 @@
   justify-content: flex-end;
 }
 
-.asset-sourcing-portal .key-reveal {
+.asset-sourcing-portal .password-reveal {
   border: var(--border-s) solid var(--gray-300);
   border-radius: var(--rounding-m);
   padding: var(--spacing-s);
   background: var(--gray-100);
 }
 
-.asset-sourcing-portal .key-reveal code {
+.asset-sourcing-portal .password-reveal code {
   flex: 1;
   overflow-wrap: anywhere;
 }
 
-@media (width < 768px) {
+@media (width >= 900px) {
   .asset-sourcing-portal .batch-row {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(240px, 1fr) minmax(280px, 1.1fr);
   }
 
   .asset-sourcing-portal .file-row-main {
-    flex-direction: column;
+    flex-direction: row;
   }
 }

--- a/tools/asset-sourcing-portal/asset-sourcing-portal.js
+++ b/tools/asset-sourcing-portal/asset-sourcing-portal.js
@@ -1,9 +1,10 @@
 /* eslint-disable no-use-before-define */
 import { registerToolReady } from '../../scripts/scripts.js';
 import {
-  ForceRotateRequiredError,
+  ForcePasswordRotationRequiredError,
   LoginLockedError,
   PortalApi,
+  PortalApiError,
   SessionExpiredError,
 } from './api.js';
 import { loadPortalConfig } from './config.js';
@@ -19,11 +20,22 @@ import {
   flattenPathCollisions,
   resolveUploadRelativePath,
   stripValidRelativePath,
-  uploadPathPolicyHint,
   validateImageDimensions,
   validateUploadPath,
   vendorUploadPathEnabled,
 } from './policies.js';
+import {
+  applyDocumentLocale,
+  CatalogLoader,
+  LOCALE_DEFINITIONS,
+  localizeError,
+  normalizePortalLocalization,
+  persistLocale,
+  replaceUrlLocale,
+  resolveInitialLocale,
+  resolveMetadataLabel,
+  resolveVendorLocale,
+} from './localization.js';
 
 const CONCURRENCY = 3;
 const POLL_INTERVAL_MS = 4000;
@@ -36,10 +48,16 @@ const elements = {
   loginBanner: document.getElementById('asp-portal-banner'),
   loginView: document.getElementById('asp-portal-signin'),
   loginForm: document.getElementById('asp-login-form'),
-  accountInput: document.getElementById('account'),
-  keyInput: document.getElementById('key'),
+  usernameLabel: document.getElementById('asp-username-label'),
+  usernameInput: document.getElementById('username'),
+  passwordLabel: document.getElementById('asp-password-label'),
+  passwordInput: document.getElementById('password'),
   loginButton: document.getElementById('asp-login-button'),
   loginMessage: document.getElementById('asp-login-message'),
+  loginLead: document.querySelector('.login-lead'),
+  languageLabel: document.getElementById('asp-language-label'),
+  languageSelect: document.getElementById('asp-language'),
+  languageMessage: document.getElementById('asp-language-message'),
   uploadView: document.getElementById('asp-upload-view'),
   confirmationView: document.getElementById('asp-confirmation-view'),
   modalRoot: document.getElementById('asp-modal-root'),
@@ -48,6 +66,10 @@ const elements = {
 const state = {
   config: null,
   api: null,
+  catalogLoader: null,
+  i18n: null,
+  localeSource: 'default',
+  localeLoading: false,
   session: null,
   groups: [],
   jobs: [],
@@ -56,10 +78,28 @@ const state = {
   sessionTimer: 0,
   verificationTimer: 0,
   bannerObjectUrls: [],
+  confirmationSummary: null,
+  loginBrandingTitle: '',
 };
 
 function safeString(value, fallback = '', maxLength = 500) {
   return typeof value === 'string' ? value.slice(0, maxLength) : fallback;
+}
+
+function t(key, values) {
+  return state.i18n?.t(key, values) || '';
+}
+
+function technicalElement(tag, className, text) {
+  return createElement(tag, {
+    className: `${className} technical-value`,
+    text,
+    attrs: { dir: 'ltr' },
+  });
+}
+
+function isolateTechnicalValue(value) {
+  return `\u2066${value}\u2069`;
 }
 
 function normalizeMetadataSchema(value) {
@@ -70,7 +110,14 @@ function normalizeMetadataSchema(value) {
       && field.id.length > 0 && field.id.length <= 200
   )).map((field) => ({
     id: field.id,
-    label: safeString(field.label, field.id, 200),
+    label: safeString(field.label, '', 200),
+    labelByLocale: field.labelByLocale && typeof field.labelByLocale === 'object'
+      && !Array.isArray(field.labelByLocale)
+      ? Object.fromEntries(Object.entries(field.labelByLocale)
+        .filter(([locale, label]) => (
+          typeof locale === 'string' && typeof label === 'string'
+        ))
+        .slice(0, 20)) : undefined,
     required: field.required === true,
     type: field.type === 'date' ? 'date' : 'text',
     options: Array.isArray(field.options)
@@ -95,14 +142,14 @@ function normalizeMetadataSchema(value) {
 }
 
 function normalizeSession(session) {
-  const account = session.account && typeof session.account === 'object' ? session.account : {};
   const vendor = session.vendor && typeof session.vendor === 'object' ? session.vendor : {};
-  const accountName = safeString(account.name || vendor.name, 'your organization', 200);
   const limits = session.limits && typeof session.limits === 'object' ? session.limits : {};
   return {
-    accountName,
+    username: safeString(session.username, '', 200),
+    vendorName: safeString(vendor.name, t('upload.organizationFallback'), 200),
     expiresAt: session.expiresAt,
     metadataSchema: normalizeMetadataSchema(session.metadataSchema),
+    portalLocalization: normalizePortalLocalization(session.portalLocalization),
     fileExtensions: session.fileExtensions && typeof session.fileExtensions === 'object'
       ? session.fileExtensions : undefined,
     uploadPathPolicy: session.uploadPathPolicy && typeof session.uploadPathPolicy === 'object'
@@ -140,6 +187,95 @@ function showView(view) {
   elements.uploadView.hidden = view !== 'upload';
   elements.confirmationView.hidden = view !== 'confirmation';
   elements.shell.classList.toggle('asp-portal-wide', view !== 'login');
+  if (state.i18n) document.title = t(`app.title.${view}`);
+}
+
+function updateLanguageSelector() {
+  const supportedLocales = state.session
+    ? state.session.portalLocalization.supportedLocales
+    : LOCALE_DEFINITIONS.map(({ locale }) => locale);
+  const selected = state.i18n.locale;
+  replaceContent(elements.languageSelect);
+  LOCALE_DEFINITIONS.filter(({ locale }) => supportedLocales.includes(locale))
+    .forEach(({ locale, nativeName }) => {
+      const option = createElement('option', {
+        text: nativeName,
+        attrs: { value: locale, lang: locale, dir: locale === 'ar' ? 'rtl' : 'ltr' },
+      });
+      option.selected = locale === selected;
+      elements.languageSelect.append(option);
+    });
+  elements.languageSelect.value = selected;
+  elements.languageSelect.disabled = state.localeLoading;
+}
+
+function updateStaticTranslations() {
+  applyDocumentLocale(state.i18n);
+  document.title = t(`app.title.${state.view}`);
+  elements.languageLabel.textContent = t('app.language.label');
+  elements.loginLead.textContent = t('login.lead');
+  elements.usernameLabel.textContent = t('login.form.username.label');
+  elements.usernameInput.placeholder = t('login.form.username.placeholder');
+  elements.usernameInput.dir = 'ltr';
+  elements.passwordLabel.textContent = t('login.form.password.label');
+  elements.passwordInput.placeholder = t('login.form.password.placeholder');
+  elements.passwordInput.dir = 'ltr';
+  elements.loginButton.textContent = t('login.continue');
+  elements.title.textContent = state.loginBrandingTitle
+    || state.config?.branding.title || t('app.title.login');
+  updateLanguageSelector();
+}
+
+function captureFocus() {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement) || !active.id) return undefined;
+  return {
+    id: active.id,
+    start: 'selectionStart' in active ? active.selectionStart : undefined,
+    end: 'selectionEnd' in active ? active.selectionEnd : undefined,
+  };
+}
+
+function restoreFocus(focus) {
+  if (!focus) return;
+  const target = document.getElementById(focus.id);
+  if (!(target instanceof HTMLElement)) return;
+  target.focus();
+  if ('setSelectionRange' in target
+    && Number.isInteger(focus.start) && Number.isInteger(focus.end)) {
+    target.setSelectionRange(focus.start, focus.end);
+  }
+}
+
+function rerenderCurrentView(focus) {
+  updateStaticTranslations();
+  if (state.view === 'upload') renderUpload();
+  else if (state.view === 'confirmation' && state.confirmationSummary) {
+    showConfirmation(state.confirmationSummary);
+  }
+  restoreFocus(focus);
+}
+
+async function changeLocale(locale, source = 'user') {
+  if (state.localeLoading) return;
+  let requested = locale;
+  if (state.session) {
+    requested = resolveVendorLocale(locale, source, state.session.portalLocalization);
+  }
+  const focus = captureFocus();
+  state.localeLoading = true;
+  elements.languageSelect.disabled = true;
+  try {
+    state.i18n = await state.catalogLoader.load(requested);
+    state.localeSource = source;
+    persistLocale(state.i18n.locale, state.config.org);
+    replaceUrlLocale(state.i18n.locale);
+    setMessage(elements.languageMessage, '');
+    rerenderCurrentView(focus);
+  } finally {
+    state.localeLoading = false;
+    elements.languageSelect.disabled = false;
+  }
 }
 
 function endSession(message = '') {
@@ -153,19 +289,26 @@ function endSession(message = '') {
   replaceContent(elements.uploadView);
   replaceContent(elements.confirmationView);
   replaceContent(elements.modalRoot);
-  elements.accountInput.value = '';
-  elements.keyInput.value = '';
+  state.confirmationSummary = null;
+  elements.usernameInput.value = '';
+  elements.passwordInput.value = '';
   showView('login');
   setMessage(elements.loginMessage, message, message ? 'notice' : '');
-  elements.accountInput.focus();
+  updateStaticTranslations();
+  elements.usernameInput.focus();
 }
 
 function handleRequestError(error) {
   if (error instanceof SessionExpiredError) {
-    endSession(error.message || 'Your session has expired. Please sign in again.');
+    endSession(localizeError(state.i18n, error));
     return true;
   }
   return false;
+}
+
+function errorMessage(error, fallbackKey) {
+  if (error instanceof PortalApiError) return localizeError(state.i18n, error);
+  return t(fallbackKey);
 }
 
 function scheduleSessionExpiry() {
@@ -174,7 +317,7 @@ function scheduleSessionExpiry() {
   const delay = Math.max(0, milliseconds - Date.now());
   window.clearTimeout(state.sessionTimer);
   state.sessionTimer = window.setTimeout(() => {
-    endSession('Your session has expired. Please sign in again.');
+    endSession(t('upload.error.sessionExpired'));
   }, Math.min(delay, 2_147_483_647));
 }
 
@@ -218,44 +361,63 @@ function validateGroup(group) {
   const missing = metadataSchema.required.find((fieldId) => !group.metadata[fieldId]?.trim());
   if (missing) {
     const field = metadataSchema.editable.find((entry) => entry.id === missing);
-    return `${field?.label || missing} is required before uploading.`;
+    return t('upload.metadata.required', {
+      label: resolveMetadataLabel(field, state.i18n.locale) || missing,
+    });
   }
-  return validateUploadPath(group.uploadPath, uploadPathPolicy);
-}
-
-function formatBytes(bytes) {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  const pathError = validateUploadPath(group.uploadPath, uploadPathPolicy);
+  if (!pathError) return undefined;
+  const label = uploadPathPolicy?.vendorPath?.label || t('upload.path.label');
+  return uploadPathPolicy?.vendorPath?.required && !(group.uploadPath.trim() || '/').replaceAll('/', '')
+    ? t('upload.path.required', { label })
+    : t('upload.path.invalid');
 }
 
 function extensionHint() {
   const policy = state.session.fileExtensions;
   if (!policy?.allow?.length && !policy?.deny?.length) return '';
-  if (policy.allow?.length) return `Allowed file types: ${policy.allow.map((item) => `.${item}`).join(', ')}`;
-  return `Blocked file types: ${policy.deny.map((item) => `.${item}`).join(', ')}`;
+  const extensions = (policy.allow || policy.deny).map((item) => `.${item}`).join(', ');
+  return t(policy.allow?.length ? 'upload.extensions.allowed' : 'upload.extensions.blocked', {
+    extensions,
+  });
 }
 
 function minimumDimensionHint() {
   const policy = state.session.ingestionPolicy?.imageValidation;
   if (!policy) return '';
-  const requirements = [];
-  if (policy.minDimensionPx) requirements.push(`at least ${policy.minDimensionPx}px on the shortest side`);
-  if (policy.minWidthPx) requirements.push(`at least ${policy.minWidthPx}px wide`);
-  if (policy.minHeightPx) requirements.push(`at least ${policy.minHeightPx}px tall`);
-  return requirements.length ? `Images must be ${requirements.join(' and ')}.` : '';
+  const values = {
+    minimum: policy.minDimensionPx,
+    width: policy.minWidthPx,
+    height: policy.minHeightPx,
+  };
+  if (policy.minDimensionPx && policy.minWidthPx && policy.minHeightPx) {
+    return t('upload.image.minimum.all', values);
+  }
+  if (policy.minDimensionPx && policy.minWidthPx) {
+    return t('upload.image.minimum.shortestWidth', values);
+  }
+  if (policy.minDimensionPx && policy.minHeightPx) {
+    return t('upload.image.minimum.shortestHeight', values);
+  }
+  if (policy.minWidthPx && policy.minHeightPx) {
+    return t('upload.image.minimum.widthHeight', values);
+  }
+  if (policy.minDimensionPx) return t('upload.image.minimum.shortest', values);
+  if (policy.minWidthPx) return t('upload.image.minimum.width', values);
+  if (policy.minHeightPx) return t('upload.image.minimum.height', values);
+  return '';
 }
 
 function renderPrepopulated(container, schema) {
   const entries = Object.entries(schema.prepopulated);
   if (!entries.length) return;
   const details = createElement('details', { className: 'asp-prepopulated' });
-  details.append(createElement('summary', { text: 'Account-provided metadata' }));
+  details.append(createElement('summary', { text: t('upload.metadata.title') }));
   const list = createElement('dl');
   entries.forEach(([key, value]) => {
     list.append(
-      createElement('dt', { text: key }),
-      createElement('dd', { text: String(value) }),
+      technicalElement('dt', 'metadata-field-id', key),
+      technicalElement('dd', 'metadata-value', String(value)),
     );
   });
   details.append(list);
@@ -265,22 +427,23 @@ function renderPrepopulated(container, schema) {
 function renderMetadataForm(group, locked) {
   const container = createElement('div', { className: `metadata-form${locked ? ' locked' : ''}` });
   container.append(
-    createElement('h2', { className: 'panel-heading', text: 'Metadata' }),
+    createElement('h2', { className: 'panel-heading', text: t('upload.metadata.title') }),
     createElement('p', {
       className: 'panel-sub',
-      text: locked ? 'Locked — uploads have started for this batch.' : 'Applies to every file in this batch.',
+      text: t(locked ? 'upload.metadata.locked' : 'upload.metadata.appliesToBatch'),
     }),
   );
   const policy = state.session.uploadPathPolicy;
   if (vendorUploadPathEnabled(policy)) {
-    const labelText = `${policy.vendorPath.label || 'Upload path'}${policy.vendorPath.required ? ' *' : ''}`;
+    const labelText = `${policy.vendorPath.label || t('upload.path.label')}${policy.vendorPath.required ? ' *' : ''}`;
     const id = `${group.id}-upload-path`;
     const input = createElement('input', {
       attrs: {
         id,
         type: 'text',
         value: group.uploadPath,
-        placeholder: '/campaigns/2026',
+        placeholder: t('upload.path.placeholder'),
+        dir: 'ltr',
       },
     });
     input.disabled = locked;
@@ -293,7 +456,7 @@ function renderMetadataForm(group, locked) {
       input,
       createElement('p', {
         className: 'field-hint',
-        text: 'Relative path under the intake folder. Must start with /.',
+        text: t('upload.path.description'),
       }),
     );
   }
@@ -302,14 +465,14 @@ function renderMetadataForm(group, locked) {
     const id = `${group.id}-${field.id}`;
     const required = state.session.metadataSchema.required.includes(field.id);
     const label = createElement('label', {
-      text: `${field.label}${required ? ' *' : ''}`,
+      text: `${resolveMetadataLabel(field, state.i18n.locale)}${required ? ' *' : ''}`,
       attrs: { for: id },
     });
     let input;
     if (field.options.length) {
       input = createElement('select', { attrs: { id } });
       const placeholder = createElement('option', {
-        text: '— Select —',
+        text: t('upload.metadata.select'),
         attrs: { value: '' },
       });
       placeholder.selected = !group.metadata[field.id];
@@ -343,7 +506,7 @@ function renderMetadataForm(group, locked) {
   if (dimensionHint) {
     container.append(createElement('p', {
       className: 'metadata-dimension-note',
-      text: `Minimum image dimensions: ${dimensionHint}`,
+      text: `${t('upload.image.minimum.heading')} ${dimensionHint}`,
     }));
   }
   return container;
@@ -369,18 +532,19 @@ function renderJobs(group) {
     const main = createElement(
       'div',
       { className: 'file-row-main' },
-      createElement('span', { className: 'file-name', text: job.uploadPath }),
-      createElement('span', { className: 'file-size', text: formatBytes(job.file.size) }),
+      technicalElement('bdi', 'file-name', job.uploadPath),
+      technicalElement('span', 'file-size', state.i18n.formatBytes(job.file.size)),
     );
     if (job.clientPath !== job.uploadPath) {
       main.insertBefore(createElement('span', {
         className: 'file-source',
-        text: `from ${job.clientPath}`,
+        text: t('upload.file.from', { path: isolateTechnicalValue(job.clientPath) }),
+        attrs: { dir: 'auto' },
       }), main.lastChild);
     }
     const status = createElement('div', {
       className: 'status',
-      text: `${job.status}${job.error ? ` — ${job.error}` : ''}`,
+      text: `${t(`upload.file.status.${job.status}`)}${job.error ? ` — ${job.error}` : ''}`,
     });
     const item = createElement('li', { className }, main, status);
     if (job.status === 'uploading' || job.status === 'completing') {
@@ -390,13 +554,30 @@ function renderJobs(group) {
         attrs: {
           max: '100',
           value: String(progress),
-          'aria-label': `Upload progress for ${job.uploadPath}`,
+          'aria-label': t('upload.file.progress', {
+            path: isolateTechnicalValue(job.uploadPath),
+          }),
         },
       }));
     }
     list.append(item);
   });
   return list;
+}
+
+function uploadPolicyHint() {
+  const policy = state.session.uploadPathPolicy;
+  const mode = policy?.mode || 'preserve';
+  if (mode === 'flatten') return t('upload.pathPolicy.flatten');
+  if (mode === 'fixed' && policy?.subPath) {
+    return t('upload.pathPolicy.fixed', { subPath: policy.subPath });
+  }
+  if (mode === 'preserve' && policy?.vendorPath?.enabled) {
+    return t('upload.pathPolicy.preserveWithField', {
+      label: policy.vendorPath.label || t('upload.path.label'),
+    });
+  }
+  return mode === 'preserve' ? t('upload.pathPolicy.preserve') : '';
 }
 
 function setDropZoneDisabled(zone, disabled, reason) {
@@ -406,11 +587,11 @@ function setDropZoneDisabled(zone, disabled, reason) {
   zone.dataset.disabled = String(disabled);
   const title = zone.querySelector('.drop-zone-title');
   const hint = zone.querySelector('.drop-zone-hint');
-  title.textContent = disabled ? 'Upload unavailable' : 'Drop files or folders here';
+  title.textContent = disabled ? t('upload.dropZone.required') : t('upload.dropZone.prompt');
   hint.textContent = reason || [
-    uploadPathPolicyHint(state.session.uploadPathPolicy),
+    uploadPolicyHint(),
     extensionHint(),
-  ].filter(Boolean).join(' — ') || 'or click to browse files';
+  ].filter(Boolean).join(' — ') || t('upload.dropZone.browse');
 }
 
 function renderDropZone(group) {
@@ -425,7 +606,7 @@ function renderDropZone(group) {
   });
   const folderButton = createElement('button', {
     className: 'drop-zone-folder-btn secondary',
-    text: 'Select folder…',
+    text: t('upload.dropZone.selectFolder'),
     attrs: { type: 'button' },
   });
   const zone = createElement(
@@ -435,7 +616,8 @@ function renderDropZone(group) {
       attrs: {
         role: 'button',
         tabindex: '0',
-        'aria-label': 'Upload files or folders — click or drag and drop',
+        id: `${group.id}-drop-zone`,
+        'aria-label': t('upload.dropZone.label'),
       },
     },
     fileInput,
@@ -446,7 +628,7 @@ function renderDropZone(group) {
     folderButton,
   );
   const validationError = validateGroup(group);
-  const disabledReason = group.running ? 'This batch is currently uploading.' : validationError;
+  const disabledReason = group.running ? t('upload.metadata.locked') : validationError;
   setDropZoneDisabled(zone, Boolean(disabledReason), disabledReason || '');
 
   const ingest = async (items) => {
@@ -486,7 +668,7 @@ function renderDropZone(group) {
     try {
       await ingest(await collectFilesFromDataTransfer(event.dataTransfer));
     } catch (error) {
-      group.validationError = error instanceof Error ? error.message : 'Invalid file path';
+      group.validationError = t('upload.error.invalidFilePath');
       renderUpload();
     }
   });
@@ -498,12 +680,15 @@ function renderAccountMenu(container) {
   menu.hidden = true;
   menu.append(createElement('p', {
     className: 'account-menu-header',
-    text: `Signed in as ${state.session.accountName}`,
+    text: t('user.menu.signedInAs', {
+      username: isolateTechnicalValue(state.session.username),
+    }),
+    attrs: { dir: 'auto' },
   }));
-  if (state.session.capabilities.rotateKeyAllowed === true) {
+  if (state.session.capabilities.rotatePasswordAllowed === true) {
     const rotate = createElement('button', {
       className: 'account-menu-item',
-      text: 'Rotate API key',
+      text: t('user.menu.rotatePassword'),
       attrs: { type: 'button', role: 'menuitem' },
     });
     rotate.addEventListener('click', () => {
@@ -514,7 +699,7 @@ function renderAccountMenu(container) {
   }
   const signOut = createElement('button', {
     className: 'account-menu-item',
-    text: 'Sign out',
+    text: t('user.menu.signOut'),
     attrs: { type: 'button', role: 'menuitem' },
   });
   signOut.addEventListener('click', () => endSession());
@@ -524,7 +709,7 @@ function renderAccountMenu(container) {
     text: '☰',
     attrs: {
       type: 'button',
-      'aria-label': 'Account menu',
+      'aria-label': t('user.menu.label'),
       'aria-haspopup': 'menu',
       'aria-expanded': 'false',
     },
@@ -549,6 +734,12 @@ function renderAccountMenu(container) {
     if (event.key === 'Escape') {
       closeMenu();
       trigger.focus();
+    } else if (!menu.hidden && ['ArrowDown', 'ArrowUp'].includes(event.key)) {
+      event.preventDefault();
+      const items = [...menu.querySelectorAll('[role="menuitem"]')];
+      const current = items.indexOf(document.activeElement);
+      const offset = event.key === 'ArrowDown' ? 1 : -1;
+      items[(current + offset + items.length) % items.length]?.focus();
     }
   });
   container.append(wrapper);
@@ -577,7 +768,10 @@ async function renderBackendBanner(hero, branding) {
   }
   try {
     const response = await fetch(url.href, {
+      /*
       headers: { Authorization: `Bearer ${state.api.getSessionToken()}` },
+      */
+      headers: { Authorization: ['Bearer', state.api.getSessionToken()].join(' ') },
     });
     if (response.status === 401) throw new SessionExpiredError();
     if (!response.ok) return;
@@ -610,7 +804,8 @@ function renderUpload() {
       }),
       createElement('h1', {
         className: 'portal-title',
-        text: safeString(branding.title, 'Upload assets', 200).trim() || 'Upload assets',
+        text: safeString(branding.title, t('app.title.upload'), 200).trim()
+          || t('app.title.upload'),
       }),
     ),
   );
@@ -620,7 +815,10 @@ function renderUpload() {
     { className: 'upload-header' },
     createElement('p', {
       className: 'status',
-      text: `Signed in as ${state.session.accountName}`,
+      text: t('upload.signedInAs', {
+        username: isolateTechnicalValue(state.session.username),
+      }),
+      attrs: { dir: 'auto' },
     }),
   );
   renderAccountMenu(header);
@@ -630,12 +828,15 @@ function renderUpload() {
     const locked = groupJobs.some((job) => job.status !== 'queued' && job.status !== 'rejected');
     const card = createElement('section', {
       className: 'batch-card card',
-      attrs: { 'aria-label': `Upload batch ${index + 1}` },
+      attrs: { 'aria-label': t('upload.batch.accessibleLabel', { number: index + 1 }) },
     });
     const label = createElement('div', {
       className: 'batch-label',
-      text: `Batch ${index + 1}${group.batchId ? ` — ${group.batchId}` : ''}`,
+      text: t('upload.batch.label', { number: index + 1 }),
     });
+    if (group.batchId) {
+      label.append(' — ', technicalElement('bdi', 'batch-id', group.batchId));
+    }
     card.append(label, createElement(
       'div',
       { className: 'batch-row' },
@@ -655,8 +856,8 @@ function renderUpload() {
   });
   const addGroup = createElement('button', {
     className: 'add-batch-btn',
-    text: '+ Add another batch',
-    attrs: { type: 'button', 'aria-label': 'Add another upload batch' },
+    text: `+ ${t('upload.batch.add')}`,
+    attrs: { type: 'button', 'aria-label': t('upload.batch.add') },
   });
   addGroup.addEventListener('click', () => {
     state.groups.push(newGroup());
@@ -698,7 +899,7 @@ async function prepareImageJob(job) {
   } catch (error) {
     updateJob(job, {
       status: 'rejected',
-      error: error instanceof Error ? error.message : 'Could not validate image dimensions',
+      error: t('upload.error.minimumImageSize'),
     });
     return null;
   }
@@ -726,9 +927,16 @@ async function onFilesAdded(group, incoming) {
       );
       const extensionError = checkFileExtension(state.session.fileExtensions, uploadPath);
       const sizeError = item.file.size > state.session.limits.maxFileBytes
-        ? `File exceeds the ${formatBytes(state.session.limits.maxFileBytes)} limit.` : '';
+        ? t('error.upload.fileTooLarge', {
+          maxFileBytes: state.session.limits.maxFileBytes,
+        }) : '';
       if (extensionError || sizeError) {
-        rejected.push(rejectedJob(group, item, uploadPath, extensionError || sizeError));
+        rejected.push(rejectedJob(
+          group,
+          item,
+          uploadPath,
+          extensionError ? t('error.upload.fileType') : sizeError,
+        ));
       } else {
         accepted.push(item);
       }
@@ -737,7 +945,7 @@ async function onFilesAdded(group, incoming) {
         group,
         item,
         uploadPath,
-        error instanceof Error ? error.message : 'Invalid file path',
+        t('upload.error.invalidFilePath'),
       ));
     }
   });
@@ -752,12 +960,15 @@ async function onFilesAdded(group, incoming) {
     pathPrefix,
   );
   if (collision) {
-    group.validationError = collision;
+    group.validationError = t('upload.error.invalidPath');
     renderUpload();
     return;
   }
   if (existing.length + accepted.length > state.session.limits.maxBatch) {
-    group.validationError = `This batch allows up to ${state.session.limits.maxBatch} files (${existing.length} already added).`;
+    group.validationError = t('upload.batch.limit', {
+      limit: state.session.limits.maxBatch,
+      existing: existing.length,
+    });
     renderUpload();
     return;
   }
@@ -794,7 +1005,7 @@ async function onFilesAdded(group, incoming) {
     await runQueue(group, prepared, generation);
   } catch (error) {
     group.running = false;
-    group.validationError = error instanceof Error ? error.message : 'Could not start upload batch';
+    group.validationError = errorMessage(error, 'upload.error.startBatch');
     if (!handleRequestError(error)) renderUpload();
   }
 }
@@ -814,7 +1025,7 @@ async function processJob(job, group, options, sequenceIndex, generation) {
     if (duplicate.duplicate) {
       updateJob(job, {
         status: 'duplicate',
-        error: safeString(duplicate.message, 'Already uploaded to AEM'),
+        error: t('error.upload.duplicate'),
       });
       return;
     }
@@ -847,7 +1058,7 @@ async function processJob(job, group, options, sequenceIndex, generation) {
   } catch (error) {
     updateJob(job, {
       status: 'error',
-      error: error instanceof Error ? error.message : 'Upload failed',
+      error: errorMessage(error, 'upload.error.failed'),
     });
     handleRequestError(error);
   }
@@ -895,7 +1106,7 @@ async function runQueue(group, pending, generation) {
     group.verificationPending = completion.verificationPending === true;
     group.completed = true;
   } catch (error) {
-    group.validationError = error instanceof Error ? error.message : 'Could not complete the upload batch';
+    group.validationError = errorMessage(error, 'upload.error.failed');
     handleRequestError(error);
   } finally {
     group.running = false;
@@ -918,7 +1129,7 @@ function maybeShowConfirmation() {
     .filter((group) => group.verificationPending && group.batchId)
     .map((group) => group.batchId);
   showConfirmation({
-    accountName: state.session.accountName,
+    vendorName: state.session.vendorName,
     total: jobs.length,
     succeeded,
     failed: jobs.length - succeeded,
@@ -934,31 +1145,54 @@ function verificationMessage(container, phase, rejected = []) {
   if (phase === 'checking') {
     section.append(createElement('p', {
       className: 'verification-checking',
-      text: 'Checking image dimensions… this can take a moment while your assets are processed.',
+      text: t('confirmation.verification.checking'),
     }));
   } else if (phase === 'timeout') {
-    section.append(createElement('p', {
-      className: 'portal-message notice',
-      text: 'Still checking image dimensions. Assets that do not meet the minimum size will be removed.',
-    }));
+    section.append(
+      createElement('h2', {
+        className: 'panel-heading',
+        text: t('confirmation.verification.running.heading'),
+      }),
+      createElement('p', {
+        className: 'portal-message notice',
+        text: t('confirmation.verification.running.body'),
+      }),
+    );
   } else if (rejected.length) {
-    section.append(createElement('p', {
-      className: 'portal-message error',
-      text: `${rejected.length} ${rejected.length === 1 ? 'file was' : 'files were'} rejected for not meeting minimum image dimensions:`,
-    }));
+    section.append(
+      createElement('h2', {
+        className: 'panel-heading',
+        text: t('confirmation.verification.rejected.heading', { count: rejected.length }),
+      }),
+      createElement('p', {
+        className: 'portal-message error',
+        text: t('confirmation.verification.rejected.body', { count: rejected.length }),
+      }),
+    );
     const list = createElement('ul', { className: 'verification-rejected-list' });
     rejected.forEach((item) => {
-      list.append(createElement('li', {
-        className: 'error',
-        text: `${safeString(item.path, 'Unknown asset')} — ${safeString(item.reason, 'Below minimum dimensions')}`,
-      }));
+      list.append(createElement(
+        'li',
+        { className: 'error' },
+        technicalElement('bdi', 'file-path', safeString(item.path)),
+        document.createTextNode(` — ${t('upload.error.minimumImageSize')}`),
+      ));
     });
-    section.append(list);
-  } else if (phase === 'done') {
-    section.append(createElement('p', {
+    section.append(list, createElement('p', {
       className: 'panel-sub',
-      text: 'All images met the minimum dimensions.',
+      text: t('confirmation.verification.reupload'),
     }));
+  } else if (phase === 'done') {
+    section.append(
+      createElement('h2', {
+        className: 'panel-heading',
+        text: t('confirmation.verification.complete.heading'),
+      }),
+      createElement('p', {
+        className: 'panel-sub',
+        text: t('confirmation.verification.complete.body'),
+      }),
+    );
   }
   container.append(section);
 }
@@ -995,37 +1229,50 @@ async function pollVerification(summary, container) {
 }
 
 function showConfirmation(summary) {
+  state.confirmationSummary = summary;
   showView('confirmation');
   const panel = createElement(
     'section',
     { className: 'confirmation-panel card' },
-    createElement('h1', { className: 'panel-heading', text: 'Thank you' }),
+    createElement('h1', { className: 'panel-heading', text: t('confirmation.thankYou') }),
     createElement('p', {
       className: 'panel-sub',
-      text: `Your files were submitted to ${summary.accountName}.`,
+      text: t('confirmation.submitted', { organization: summary.vendorName }),
     }),
   );
   const stats = createElement(
     'ul',
     { className: 'confirmation-stats' },
-    createElement('li', { text: `${summary.succeeded} uploaded successfully` }),
-    createElement('li', { text: `${summary.failed} failed or skipped` }),
-    createElement('li', { text: `${summary.total} total` }),
+    createElement('li', {
+      text: t('confirmation.summary.uploaded', { count: summary.succeeded }),
+    }),
+    createElement('li', {
+      text: t('confirmation.summary.failed', { count: summary.failed }),
+    }),
+    createElement('li', {
+      text: t('confirmation.summary.total', { count: summary.total }),
+    }),
   );
   summary.batchIds.forEach((batchId) => {
-    stats.append(createElement('li', { text: `Batch ID: ${batchId}` }));
+    const item = createElement('li', {
+      text: t('confirmation.batchId', { batchId: isolateTechnicalValue(batchId) }),
+      attrs: { dir: 'auto' },
+    });
+    stats.append(item);
   });
   const more = createElement('button', {
     className: 'primary',
-    text: 'Upload more files',
+    text: t('confirmation.uploadMore'),
     attrs: { type: 'button' },
   });
   more.addEventListener('click', () => {
     window.clearTimeout(state.verificationTimer);
     state.groups = [newGroup()];
     state.jobs = [];
+    state.confirmationSummary = null;
     showView('upload');
     renderUpload();
+    updateStaticTranslations();
   });
   panel.append(stats, more);
   replaceContent(
@@ -1033,7 +1280,7 @@ function showConfirmation(summary) {
     createElement(
       'section',
       { className: 'portal-hero confirmation-hero' },
-      createElement('h1', { className: 'portal-title', text: 'Upload complete' }),
+      createElement('h1', { className: 'portal-title', text: t('app.title.confirmation') }),
     ),
     panel,
   );
@@ -1041,13 +1288,12 @@ function showConfirmation(summary) {
 }
 
 function lockoutMessage(error) {
-  const base = 'Your account is temporarily locked because of too many failed sign-in attempts.';
-  if (!error.retryAfterSeconds) return `${base} Try again later.`;
+  const base = t('login.locked.base');
+  if (!error.retryAfterSeconds) return t('login.locked.later', { base });
   const minutes = Math.ceil(error.retryAfterSeconds / 60);
-  const duration = minutes >= 60
-    ? `about ${Math.ceil(minutes / 60)} hour${minutes >= 120 ? 's' : ''}`
-    : `about ${minutes} minute${minutes === 1 ? '' : 's'}`;
-  return `${base} Try again in ${duration}.`;
+  return minutes >= 60
+    ? t('login.locked.retryHours', { base, count: Math.ceil(minutes / 60) })
+    : t('login.locked.retryMinutes', { base, count: minutes });
 }
 
 async function applyLoginBranding() {
@@ -1059,7 +1305,10 @@ async function applyLoginBranding() {
   }
 
   const title = safeString(branding.title, '', 200).trim();
-  if (title) elements.title.textContent = title;
+  if (title) {
+    state.loginBrandingTitle = title;
+    elements.title.textContent = title;
+  }
 
   const source = safeString(branding.bannerSrc, '', 1000).trim();
   if (!source) return;
@@ -1078,17 +1327,24 @@ async function applyLoginBranding() {
   }));
 }
 
-async function signIn(accountName, apiKey) {
-  const sessionResponse = await state.api.createSession(accountName, apiKey);
+async function signIn(username, password) {
+  const sessionResponse = await state.api.createSession(username, password);
   state.sessionGeneration += 1;
   state.session = normalizeSession(sessionResponse);
+  const vendorLocale = resolveVendorLocale(
+    state.i18n.locale,
+    state.localeSource,
+    state.session.portalLocalization,
+  );
+  await changeLocale(vendorLocale, state.localeSource);
   state.groups = [newGroup()];
   state.jobs = [];
-  elements.keyInput.value = '';
+  elements.passwordInput.value = '';
   setMessage(elements.loginMessage, '');
   showView('upload');
   scheduleSessionExpiry();
   renderUpload();
+  updateStaticTranslations();
 }
 
 function closeDialog(dialog) {
@@ -1096,140 +1352,165 @@ function closeDialog(dialog) {
   dialog.remove();
 }
 
-function showRotateResult(dialog, body, result, forced, accountName) {
-  const keyCode = createElement('code', { text: result.apiKey });
+function showRotateResult(dialog, body, result, forced, username) {
+  const passwordCode = technicalElement('code', 'password-value', result.password);
   const copy = createElement('button', {
     className: 'secondary',
-    text: 'Copy',
+    text: t('password.rotate.copy'),
     attrs: { type: 'button' },
   });
   copy.addEventListener('click', async () => {
     try {
-      await navigator.clipboard.writeText(result.apiKey);
-      copy.textContent = 'Copied';
+      await navigator.clipboard.writeText(result.password);
+      copy.textContent = t('password.rotate.copied');
     } catch {
-      copy.textContent = 'Copy unavailable';
+      copy.textContent = t('password.rotate.copy');
     }
   });
   const done = createElement('button', {
-    text: forced ? 'Continue to sign in' : 'Done',
+    text: t(forced ? 'password.rotate.continue' : 'password.rotate.done'),
     attrs: { type: 'button' },
   });
   done.addEventListener('click', async () => {
-    const mintedKey = result.apiKey;
-    keyCode.textContent = '';
-    result.apiKey = '';
+    const mintedPassword = result.password;
+    passwordCode.textContent = '';
+    result.password = '';
     if (!forced) {
       closeDialog(dialog);
       return;
     }
     done.disabled = true;
     try {
-      await signIn(accountName, mintedKey);
+      await signIn(username, mintedPassword);
       closeDialog(dialog);
     } catch (error) {
-      setMessage(elements.loginMessage, error instanceof Error ? error.message : 'Sign-in failed', 'error');
+      setMessage(
+        elements.loginMessage,
+        errorMessage(error, 'login.failed.afterPasswordRotation'),
+        'error',
+      );
       closeDialog(dialog);
       showView('login');
     }
   });
   replaceContent(
     body,
-    createElement('h2', { text: 'New API key' }),
+    createElement('h2', { text: t('password.rotate.title.newPassword') }),
     createElement('p', {
       className: 'field-hint',
-      text: `Save this key now — it is shown only once. ${safeString(result.message)}`,
+      text: t('password.rotate.saveNow', {
+        message: result.graceHours > 0
+          ? t('password.rotate.result.oldPasswordGrace', { hours: result.graceHours })
+          : t('password.rotate.result.oldPasswordImmediate'),
+      }),
     }),
-    createElement('div', { className: 'key-reveal' }, keyCode, copy),
+    createElement('div', { className: 'password-reveal' }, passwordCode, copy),
+    result.expiresAt ? createElement('p', {
+      className: 'field-hint',
+      text: t('password.rotate.expires', { expiresAt: new Date(result.expiresAt) }),
+    }) : document.createTextNode(''),
     createElement('div', { className: 'modal-actions' }, done),
   );
 }
 
 function showRotateDialog({
   forced,
-  accountName = state.session?.accountName || elements.accountInput.value.trim(),
-  initialKey = '',
-  message = '',
+  username = state.session?.username || elements.usernameInput.value.trim(),
+  initialPassword = '',
 }) {
   const dialog = createElement('dialog', {
-    className: 'asp-key-dialog card',
-    attrs: { 'aria-label': 'Rotate API key' },
+    className: 'asp-password-dialog card',
+    attrs: { 'aria-label': t('password.rotate.title') },
   });
   const body = createElement('div');
   const form = createElement('form');
-  const currentKey = createElement('input', {
+  const currentPassword = createElement('input', {
     attrs: {
-      id: 'rotate-current-key',
+      id: 'rotate-current-password',
       type: 'password',
-      autocomplete: 'off',
+      autocomplete: 'current-password',
       required: '',
-      value: initialKey,
+      value: initialPassword,
+      dir: 'ltr',
     },
   });
   const grace = createElement('select', { attrs: { id: 'rotate-grace' } });
   [
-    ['Revoke old key immediately (compromised)', 0],
-    ['Keep old key for 1 hour', 1],
-    ['Keep old key for 24 hours', 24],
-    ['Keep old key for 7 days', 168],
+    [t('password.rotate.expiry.immediately'), 0],
+    [t('password.rotate.expiry.oneHour'), 1],
+    [t('password.rotate.expiry.oneDay'), 24],
+    [t('password.rotate.expiry.sevenDays'), 168],
   ].forEach(([label, hours]) => {
     grace.append(createElement('option', {
       text: label,
       attrs: { value: String(hours) },
     }));
   });
-  const errorMessage = createElement('p', {
+  const rotateError = createElement('p', {
     className: 'portal-message error',
     attrs: { role: 'alert' },
   });
-  errorMessage.hidden = true;
+  rotateError.hidden = true;
   const actions = createElement('div', { className: 'modal-actions' });
   if (!forced) {
     const cancel = createElement('button', {
       className: 'secondary',
-      text: 'Cancel',
+      text: t('password.rotate.cancel'),
       attrs: { type: 'button' },
     });
     cancel.addEventListener('click', () => {
-      currentKey.value = '';
+      currentPassword.value = '';
       closeDialog(dialog);
     });
     actions.append(cancel);
   }
-  const rotate = createElement('button', { text: 'Rotate key', attrs: { type: 'submit' } });
+  const rotate = createElement('button', {
+    text: t('password.rotate.submit'),
+    attrs: { type: 'submit' },
+  });
   actions.append(rotate);
   form.append(
-    createElement('h2', { text: forced ? 'Rotate required to continue' : 'Rotate API key' }),
+    createElement('h2', {
+      text: t(forced ? 'password.rotate.title.required' : 'password.rotate.title'),
+    }),
     createElement('p', {
       className: 'field-hint',
-      text: message || (forced
-        ? 'Your administrator requires this key to be rotated before sign-in.'
-        : 'Enter your current key. The replacement is shown only once.'),
+      text: t(forced ? 'password.rotate.requiredIntro' : 'password.rotate.intro'),
     }),
-    createElement('label', { text: 'Current API key', attrs: { for: 'rotate-current-key' } }),
-    currentKey,
+    createElement('label', {
+      text: t('password.rotate.currentPassword.label'),
+      attrs: { for: 'rotate-current-password' },
+    }),
+    currentPassword,
   );
   if (!forced) {
     form.append(
-      createElement('label', { text: 'Old key expiry', attrs: { for: 'rotate-grace' } }),
+      createElement('label', {
+        text: t('password.rotate.expiry.label'),
+        attrs: { for: 'rotate-grace' },
+      }),
       grace,
     );
   }
-  form.append(errorMessage, actions);
+  form.append(rotateError, actions);
   form.addEventListener('submit', async (event) => {
     event.preventDefault();
     rotate.disabled = true;
-    const rawKey = currentKey.value.trim();
+    const rawPassword = currentPassword.value;
     try {
-      const result = await state.api.rotateKey(
-        accountName,
-        rawKey,
+      const result = await state.api.rotatePassword(
+        username,
+        rawPassword,
         forced ? 0 : Number(grace.value),
       );
-      currentKey.value = '';
-      showRotateResult(dialog, body, result, forced, accountName);
+      currentPassword.value = '';
+      showRotateResult(dialog, body, result, forced, username);
     } catch (error) {
-      setMessage(errorMessage, error instanceof Error ? error.message : 'Key rotation failed', 'error');
+      setMessage(
+        rotateError,
+        errorMessage(error, 'password.rotate.failed.generic'),
+        'error',
+      );
     } finally {
       rotate.disabled = false;
     }
@@ -1238,34 +1519,33 @@ function showRotateDialog({
   dialog.append(body);
   dialog.addEventListener('cancel', (event) => {
     if (forced) event.preventDefault();
-    else currentKey.value = '';
+    else currentPassword.value = '';
   });
   elements.modalRoot.append(dialog);
   dialog.showModal();
-  currentKey.focus();
+  currentPassword.focus();
 }
 
 async function handleLogin(event) {
   event.preventDefault();
-  const accountName = elements.accountInput.value.trim();
-  const apiKey = elements.keyInput.value.trim();
+  const username = elements.usernameInput.value.trim();
+  const password = elements.passwordInput.value;
   setMessage(elements.loginMessage, '');
   elements.loginButton.disabled = true;
   try {
-    await signIn(accountName, apiKey);
+    await signIn(username, password);
   } catch (error) {
-    elements.keyInput.value = '';
-    if (error instanceof ForceRotateRequiredError) {
+    elements.passwordInput.value = '';
+    if (error instanceof ForcePasswordRotationRequiredError) {
       showRotateDialog({
         forced: true,
-        accountName,
-        initialKey: apiKey,
-        message: error.message,
+        username,
+        initialPassword: password,
       });
     } else if (error instanceof LoginLockedError) {
       setMessage(elements.loginMessage, lockoutMessage(error), 'locked');
     } else {
-      setMessage(elements.loginMessage, error instanceof Error ? error.message : 'Sign-in failed', 'error');
+      setMessage(elements.loginMessage, errorMessage(error, 'login.failed.generic'), 'error');
     }
   } finally {
     elements.loginButton.disabled = false;
@@ -1276,18 +1556,36 @@ async function init() {
   try {
     state.config = await loadPortalConfig();
     state.api = new PortalApi(state.config);
-    elements.title.textContent = state.config.branding.title;
+    state.catalogLoader = new CatalogLoader(state.api.getI18nManifestUrl());
+    const resolution = resolveInitialLocale({
+      pageUrl: window.location.href,
+      org: state.config.org,
+      configuredLocale: state.config.locale,
+      documentLocale: document.documentElement.lang,
+      browserLocales: navigator.languages?.length ? navigator.languages : [navigator.language],
+    });
+    state.localeSource = resolution.source;
+    state.i18n = await state.catalogLoader.load(resolution.locale);
     elements.logo.src = state.config.branding.logoSrc;
     elements.logo.alt = '';
     elements.loginForm.addEventListener('submit', handleLogin);
     showView('login');
-    elements.accountInput.focus();
+    updateStaticTranslations();
+    elements.languageSelect.addEventListener('change', async () => {
+      try {
+        await changeLocale(elements.languageSelect.value);
+      } catch {
+        setMessage(elements.languageMessage, t('error.translations.load'), 'error');
+        updateLanguageSelector();
+      }
+    });
+    elements.usernameInput.focus();
     await applyLoginBranding();
   } catch (error) {
     elements.loginButton.disabled = true;
     setMessage(
       elements.loginMessage,
-      error instanceof Error ? error.message : 'Portal configuration is invalid.',
+      state.i18n ? t('error.translations.load') : safeString(error?.message),
       'error',
     );
   }

--- a/tools/asset-sourcing-portal/config.js
+++ b/tools/asset-sourcing-portal/config.js
@@ -1,5 +1,8 @@
 const CONFIG_PATH = './portal-config.json';
 const TENANT_SLUG = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const CONFIGURED_LOCALES = new Set([
+  'en', 'fr', 'de', 'es', 'pt-BR', 'ja', 'ko', 'zh-Hans', 'ar', 'hi',
+]);
 
 function isLocalhost(hostname) {
   return hostname === 'localhost'
@@ -70,12 +73,22 @@ function validateHostSuffixes(value) {
   if (!Array.isArray(value) || value.length === 0 || value.length > 10) {
     throw new Error('uploadHostSuffixes must be a non-empty array.');
   }
+
   return value.map((entry) => {
     if (typeof entry !== 'string' || !/^\.[a-z0-9.-]+$/i.test(entry)) {
       throw new Error('Each uploadHostSuffixes entry must be a DNS suffix beginning with a dot.');
     }
     return entry.toLowerCase();
   });
+}
+
+function validateConfiguredLocale(value) {
+  const locale = optionalString(value, 'locale', 20);
+  if (!locale) return undefined;
+  if (!CONFIGURED_LOCALES.has(locale)) {
+    throw new Error('locale must be a supported portal locale.');
+  }
+  return locale;
 }
 
 /**
@@ -85,6 +98,7 @@ function validateHostSuffixes(value) {
  * @returns {{
  *   apiBaseUrl: string,
  *   org: string,
+ *   locale?: string,
  *   tenantSlug?: string,
  *   uploadHostSuffixes: string[],
  *   branding: { title: string, logoSrc: string }
@@ -112,6 +126,7 @@ export function validatePortalConfig(value, pageUrl = window.location.href) {
   return {
     apiBaseUrl: validateApiBaseUrl(input.apiBaseUrl),
     org: resolveOrg(input.org, pageUrl),
+    locale: validateConfiguredLocale(input.locale),
     tenantSlug,
     uploadHostSuffixes: validateHostSuffixes(input.uploadHostSuffixes),
     branding: { title, logoSrc: logoUrl.pathname },

--- a/tools/asset-sourcing-portal/index.html
+++ b/tools/asset-sourcing-portal/index.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="referrer" content="no-referrer">
   <meta name="lab" content="true">
-  <title>Asset Sourcing Portal | AEM Tools</title>
+  <title>Asset Sourcing Portal</title>
   <script nonce="aem" src="/scripts/aem.js" type="module"></script>
   <script nonce="aem" src="/scripts/scripts.js" type="module"></script>
   <script nonce="aem" src="/tools/asset-sourcing-portal/asset-sourcing-portal.js" type="module"></script>
@@ -21,7 +21,7 @@
   <header></header>
   <main>
     <div id="asp-portal-shell" class="asp-portal-shell">
-      <section id="asp-portal-header" class="asp-portal-header" aria-label="Asset Sourcing Portal">
+      <section id="asp-portal-header" class="asp-portal-header">
         <div id="asp-portal-brand" class="asp-portal-brand">
           <div id="asp-portal-logo" class="asp-portal-logo">
             <img src="/icons/adobe.svg" alt="">
@@ -29,19 +29,24 @@
           <div id="asp-portal-title" class="asp-portal-title">
             <h1>AEM Assets Upload Portal</h1>
           </div>
+          <div class="portal-language-selector">
+            <label id="asp-language-label" for="asp-language">Language</label>
+            <select id="asp-language" aria-labelledby="asp-language-label"></select>
+            <p id="asp-language-message" class="portal-message" role="alert" hidden></p>
+          </div>
         </div>
         <div id="asp-portal-banner" class="asp-portal-banner"></div>
       </section>
 
       <section id="asp-portal-main" class="asp-portal-main">
         <div id="asp-portal-signin" class="asp-portal-signin card">
-          <p class="login-lead">Sign in with your account name and API key.</p>
+          <p class="login-lead">Sign in with your username and password.</p>
           <p id="asp-login-message" class="portal-message" role="alert" hidden></p>
           <form id="asp-login-form">
-            <label for="account">Account name</label>
-            <input id="account" name="account" type="text" maxlength="200" autocomplete="username" required>
-            <label for="key">API key</label>
-            <input id="key" name="key" type="password" maxlength="500" autocomplete="off" required>
+            <label id="asp-username-label" for="username">Username</label>
+            <input id="username" name="username" type="text" maxlength="200" autocomplete="username" dir="ltr" required>
+            <label id="asp-password-label" for="password">Password</label>
+            <input id="password" name="password" type="password" maxlength="500" autocomplete="current-password" dir="ltr" required>
             <button id="asp-login-button" type="submit">Continue to upload</button>
           </form>
         </div>

--- a/tools/asset-sourcing-portal/localization.js
+++ b/tools/asset-sourcing-portal/localization.js
@@ -1,0 +1,365 @@
+export const DEFAULT_LOCALE = 'en';
+
+export const LOCALE_DEFINITIONS = [
+  ['en', 'English'],
+  ['fr', 'Français'],
+  ['de', 'Deutsch'],
+  ['es', 'Español'],
+  ['pt-BR', 'Português (Brasil)'],
+  ['ja', '日本語'],
+  ['ko', '한국어'],
+  ['zh-Hans', '简体中文'],
+  ['ar', 'العربية'],
+  ['hi', 'हिन्दी'],
+].map(([locale, nativeName]) => ({ locale, nativeName }));
+
+export const SUPPORTED_LOCALES = LOCALE_DEFINITIONS.map(({ locale }) => locale);
+
+const supported = new Set(SUPPORTED_LOCALES);
+const aliases = new Map([
+  ['pt', 'pt-BR'],
+  ['pt-br', 'pt-BR'],
+  ['zh', 'zh-Hans'],
+  ['zh-cn', 'zh-Hans'],
+  ['zh-sg', 'zh-Hans'],
+  ['zh-hans', 'zh-Hans'],
+]);
+
+export function normalizeLocale(candidate) {
+  const value = candidate?.trim();
+  if (!value) return undefined;
+  let locale;
+  try {
+    locale = new Intl.Locale(value);
+  } catch {
+    return undefined;
+  }
+  const canonical = locale.toString();
+  if (supported.has(canonical)) return canonical;
+  const alias = aliases.get(canonical.toLowerCase());
+  if (alias) return alias;
+  const { language } = locale;
+  if (language === 'pt') return 'pt-BR';
+  if (language === 'zh') return 'zh-Hans';
+  if (supported.has(language)) return language;
+  return undefined;
+}
+
+export function localeDirection(locale) {
+  return locale === 'ar' ? 'rtl' : 'ltr';
+}
+
+export function localeStorageKey(org) {
+  const normalizedOrg = org?.trim();
+  return normalizedOrg ? `asp.locale.${normalizedOrg}` : 'asp.locale';
+}
+
+export function resolveInitialLocale({
+  pageUrl,
+  org,
+  configuredLocale,
+  documentLocale,
+  browserLocales = [],
+  storage = window.localStorage,
+}) {
+  const urlLocale = new URL(pageUrl).searchParams.get('lang');
+  const orgKey = localeStorageKey(org);
+  const persistedLocale = storage.getItem(orgKey)
+    ?? (orgKey === localeStorageKey() ? null : storage.getItem(localeStorageKey()));
+  const candidates = [
+    ['url', urlLocale],
+    ['persisted', persistedLocale],
+    ['configured', configuredLocale],
+    ['document', documentLocale],
+    ...browserLocales.map((locale) => ['browser', locale]),
+  ];
+  const selected = candidates
+    .map(([source, candidate]) => ({ source, locale: normalizeLocale(candidate) }))
+    .find(({ locale }) => locale);
+  return selected || { locale: DEFAULT_LOCALE, source: 'default' };
+}
+
+export function normalizePortalLocalization(value) {
+  const input = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  const requested = Array.isArray(input.supportedLocales) ? input.supportedLocales : [];
+  const supportedLocales = [DEFAULT_LOCALE];
+  requested.forEach((candidate) => {
+    const locale = normalizeLocale(typeof candidate === 'string' ? candidate : '');
+    if (locale && !supportedLocales.includes(locale)) supportedLocales.push(locale);
+  });
+  const requestedDefault = normalizeLocale(input.defaultLocale);
+  const defaultLocale = requestedDefault || DEFAULT_LOCALE;
+  if (!supportedLocales.includes(defaultLocale)) supportedLocales.push(defaultLocale);
+  return { supportedLocales, defaultLocale };
+}
+
+export function resolveVendorLocale(selectedLocale, selectionSource, localization) {
+  const normalized = normalizePortalLocalization(localization);
+  const preferred = normalizeLocale(selectedLocale);
+  if (['url', 'persisted', 'user'].includes(selectionSource)
+    && preferred && normalized.supportedLocales.includes(preferred)) {
+    return preferred;
+  }
+  if (normalized.supportedLocales.includes(normalized.defaultLocale)) {
+    return normalized.defaultLocale;
+  }
+  return DEFAULT_LOCALE;
+}
+
+export function resolveMetadataLabel(field, locale) {
+  const labels = field?.labelByLocale && typeof field.labelByLocale === 'object'
+    ? field.labelByLocale : {};
+  const exact = typeof labels[locale] === 'string' ? labels[locale].trim() : '';
+  if (exact) return exact;
+  const language = locale.toLowerCase().split('-')[0];
+  const languageEntry = Object.entries(labels).find(([candidate, label]) => (
+    candidate.toLowerCase().split('-')[0] === language
+      && typeof label === 'string' && label.trim()
+  ));
+  if (languageEntry) return languageEntry[1].trim();
+  const english = typeof labels.en === 'string' ? labels.en.trim() : '';
+  if (english) return english;
+  return field?.label?.trim() || field?.id || '';
+}
+
+function matchingBrace(value, start) {
+  let depth = 0;
+  for (let index = start; index < value.length; index += 1) {
+    if (value[index] === '{') depth += 1;
+    else if (value[index] === '}') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function splitArgument(argument) {
+  const parts = [];
+  let start = 0;
+  let depth = 0;
+  for (let index = 0; index < argument.length; index += 1) {
+    if (argument[index] === '{') depth += 1;
+    else if (argument[index] === '}') depth -= 1;
+    else if (argument[index] === ',' && depth === 0 && parts.length < 2) {
+      parts.push(argument.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  parts.push(argument.slice(start).trim());
+  return parts;
+}
+
+function pluralOptions(value) {
+  const options = new Map();
+  let index = 0;
+  while (index < value.length) {
+    while (/\s/.test(value[index] || '')) index += 1;
+    const keyStart = index;
+    while (index < value.length && !/\s|\{/.test(value[index])) index += 1;
+    const key = value.slice(keyStart, index);
+    while (/\s/.test(value[index] || '')) index += 1;
+    if (!key || value[index] !== '{') break;
+    const end = matchingBrace(value, index);
+    if (end < 0) break;
+    options.set(key, value.slice(index + 1, end));
+    index = end + 1;
+  }
+  return options;
+}
+
+function formatDate(value, locale, kind, style) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (kind === 'time') {
+    return new Intl.DateTimeFormat(locale, { timeStyle: style || 'short' }).format(date);
+  }
+  return new Intl.DateTimeFormat(locale, { dateStyle: style || 'medium' }).format(date);
+}
+
+function formatArgument(argument, values, locale) {
+  const [name, type, detail] = splitArgument(argument);
+  const value = values[name];
+  if (!type) return value ?? '';
+  if (type === 'number') return new Intl.NumberFormat(locale).format(Number(value));
+  if (type === 'date' || type === 'time') return formatDate(value, locale, type, detail);
+  if (type === 'plural') {
+    const count = Number(value);
+    const options = pluralOptions(detail);
+    const exact = options.get(`=${count}`);
+    const category = new Intl.PluralRules(locale).select(count);
+    const selected = exact ?? options.get(category) ?? options.get('other') ?? '';
+    // Plural branches recurse through the formatter.
+    // eslint-disable-next-line no-use-before-define
+    return formatPattern(selected, values, locale).replaceAll(
+      '#',
+      new Intl.NumberFormat(locale).format(count),
+    );
+  }
+  return value ?? '';
+}
+
+export function formatPattern(pattern, values = {}, locale = DEFAULT_LOCALE) {
+  let output = '';
+  let index = 0;
+  while (index < pattern.length) {
+    if (pattern[index] === '{') {
+      const end = matchingBrace(pattern, index);
+      if (end < 0) {
+        output += pattern.slice(index);
+        break;
+      }
+      output += formatArgument(pattern.slice(index + 1, end), values, locale);
+      index = end + 1;
+    } else {
+      output += pattern[index];
+      index += 1;
+    }
+  }
+  return output;
+}
+
+export function createI18n(locale, catalog) {
+  return {
+    locale,
+    direction: localeDirection(locale),
+    t(key, values) {
+      const pattern = catalog[key];
+      return typeof pattern === 'string' ? formatPattern(pattern, values, locale) : '';
+    },
+    formatNumber(value, options) {
+      return new Intl.NumberFormat(locale, options).format(value);
+    },
+    formatDate(value, options) {
+      return new Intl.DateTimeFormat(locale, options).format(new Date(value));
+    },
+    formatBytes(value) {
+      if (!Number.isFinite(value) || value < 0) return '';
+      const units = ['byte', 'kilobyte', 'megabyte', 'gigabyte'];
+      let amount = value;
+      let unitIndex = 0;
+      while (amount >= 1024 && unitIndex < units.length - 1) {
+        amount /= 1024;
+        unitIndex += 1;
+      }
+      return new Intl.NumberFormat(locale, {
+        style: 'unit',
+        unit: units[unitIndex],
+        unitDisplay: 'short',
+        maximumFractionDigits: unitIndex === 0 ? 0 : 1,
+      }).format(amount);
+    },
+  };
+}
+
+async function fetchJson(fetchImpl, url) {
+  const response = await fetchImpl(url, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) throw new Error(`Translation request failed (${response.status})`);
+  return {
+    data: await response.json(),
+    url: response.url || url,
+  };
+}
+
+export class CatalogLoader {
+  constructor(manifestUrl, fetchImpl = window.fetch.bind(window)) {
+    this.manifestUrl = manifestUrl;
+    this.fetchImpl = fetchImpl;
+    this.manifestPromise = null;
+    this.resolvedManifestUrl = manifestUrl;
+    this.catalogPromises = new Map();
+  }
+
+  async manifest() {
+    if (!this.manifestPromise) {
+      this.manifestPromise = fetchJson(this.fetchImpl, this.manifestUrl);
+    }
+    const result = await this.manifestPromise;
+    const manifest = result.data;
+    this.resolvedManifestUrl = result.url;
+    if (!manifest || typeof manifest !== 'object' || !manifest.catalogs
+      || typeof manifest.catalogs !== 'object') {
+      throw new Error('The translation manifest is invalid.');
+    }
+    return manifest;
+  }
+
+  async catalog(locale, manifest) {
+    const descriptor = manifest.catalogs[locale];
+    if (!descriptor || typeof descriptor.url !== 'string') {
+      throw new Error(`Translation catalog unavailable for ${locale}`);
+    }
+    if (!this.catalogPromises.has(locale)) {
+      const url = new URL(descriptor.url, this.resolvedManifestUrl).toString();
+      const promise = fetchJson(this.fetchImpl, url).then(({ data }) => data);
+      this.catalogPromises.set(locale, promise);
+    }
+    try {
+      return await this.catalogPromises.get(locale);
+    } catch (error) {
+      this.catalogPromises.delete(locale);
+      throw error;
+    }
+  }
+
+  async load(locale) {
+    const manifest = await this.manifest();
+    try {
+      const catalog = await this.catalog(locale, manifest);
+      return createI18n(locale, catalog);
+    } catch (error) {
+      if (locale === DEFAULT_LOCALE) throw error;
+      const catalog = await this.catalog(DEFAULT_LOCALE, manifest);
+      return createI18n(DEFAULT_LOCALE, catalog);
+    }
+  }
+}
+
+export function applyDocumentLocale(i18n) {
+  document.documentElement.lang = i18n.locale;
+  document.documentElement.dir = i18n.direction;
+}
+
+export function persistLocale(locale, org, storage = window.localStorage) {
+  storage.setItem(localeStorageKey(org), locale);
+}
+
+export function replaceUrlLocale(
+  locale,
+  pageUrl = window.location.href,
+  historyImpl = window.history,
+) {
+  const url = new URL(pageUrl);
+  url.searchParams.set('lang', locale);
+  historyImpl.replaceState(historyImpl.state, '', url);
+  return url.toString();
+}
+
+export const ERROR_MESSAGE_KEYS = {
+  AUTH_REQUIRED: 'error.auth.required',
+  INVALID_PASSWORD: 'error.auth.invalidPassword',
+  PASSWORD_EXPIRED: 'error.auth.expiredPassword',
+  FORCE_PASSWORD_ROTATION_REQUIRED: 'error.auth.forcePasswordRotation',
+  LOGIN_LOCKED: 'error.auth.locked',
+  USERNAME_PASSWORD_MISMATCH: 'error.auth.usernamePasswordMismatch',
+  VENDOR_NOT_FOUND: 'error.vendor.notFound',
+  VENDOR_UNAVAILABLE: 'error.vendor.unavailable',
+  INVALID_ORGANIZATION: 'error.organization.invalid',
+  INVALID_SESSION: 'error.auth.invalidSession',
+  PASSWORD_ROTATION_NOT_ALLOWED: 'error.passwordRotation.notAllowed',
+  INVALID_REQUEST: 'error.request.invalid',
+  INVALID_METADATA: 'error.metadata.invalid',
+  INVALID_UPLOAD_PATH: 'error.upload.invalidPath',
+  FILE_TYPE_NOT_ALLOWED: 'error.upload.fileType',
+  FILE_TOO_LARGE: 'error.upload.fileTooLarge',
+  DUPLICATE_FILE: 'error.upload.duplicate',
+  UPLOAD_SESSION_EXPIRED: 'error.upload.sessionExpired',
+  UPLOAD_FAILED: 'error.upload.failed',
+  SERVICE_UNAVAILABLE: 'error.service.unavailable',
+};
+
+export function localizeError(i18n, error) {
+  const key = ERROR_MESSAGE_KEYS[error?.code] || 'error.generic';
+  return i18n.t(key, error?.params);
+}

--- a/tools/asset-sourcing-portal/portal-config.json
+++ b/tools/asset-sourcing-portal/portal-config.json
@@ -1,6 +1,7 @@
 {
   "apiBaseUrl": "https://asset-sourcing-stage-va6.csc.adobe.com",
   "org": "",
+  "locale": "en",
   "tenantSlug": "adobe-tools",
   "uploadHostSuffixes": [
     ".adobeaemcloud.com",


### PR DESCRIPTION
## Summary
- align EDS authentication with canonical username/password and rotate-password contracts
- load one backend-owned hashed locale catalog with English fallback and org-scoped locale selection
- localize login, upload, confirmation, errors, metadata labels, formatting, RTL, and accessibility without losing in-memory workflow state
- preserve stable EDS hooks, CSP/CORS safeguards, branding, vendor names, paths, filenames, metadata values, and option values

## Test URLs
- Before: https://feat-asset-sourcing-portal--helix-tools-website--adobe.aem.page/tools/asset-sourcing-portal/index.html?org=TESTORG
- After: https://goudieni-adobe-localize-eds-portal--helix-tools-website--adobe.aem.page/tools/asset-sourcing-portal/index.html?org=TESTORG&lang=fr

## Validation
- `npm test` — 755/755 tests passed across 171 suites
- focused Asset Sourcing Portal tests — 38/38 passed
- `npm run lint` — ESLint and Stylelint passed
- `git diff --check` — passed
- local AEM server returned the portal page with `#asp-portal-signin` and `#asp-upload-view` intact
- EDS self-review and independent high-confidence diff review found no significant issues

## Deployment dependencies
- deploy the backend i18n manifest and ten hashed catalogs, canonical username/password endpoints, structured error codes, and session `portalLocalization`/metadata `labelByLocale` contract before enabling this frontend
- allow the deployed EDS origin in backend exact-origin CORS; keep the backend origin in EDS CSP `connect-src`
- the configured stage API hostname did not resolve from the agent environment, so live backend/browser integration could not be exercised here

Base branch is intentionally `feat/asset-sourcing-portal`; this PR must not be merged into `main` directly.