### PR TITLE
feat(sidekick): add mixer to the plugin environments enum

### DIFF
--- a/sidekick/config.schema.json
+++ b/sidekick/config.schema.json
@@ -42,6 +42,7 @@
               "preview",
               "review",
               "live",
+              "mixer",
               "prod"
             ]
           },


### PR DESCRIPTION
syncs the sidekick config schema with adobe/helix-config-storage by adding `mixer` to the plugin `environments` enum, so the config tool accepts a plugin scoped to `*.aem.network`.
